### PR TITLE
Add failure of make.sh on any failure

### DIFF
--- a/Common/3dParty/make.sh
+++ b/Common/3dParty/make.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")


### PR DESCRIPTION
Previously some steps (like `fetch.sh` seems failing on `gclient sync -r 4.10.253` on debian systems with `ValueError: unexpected AST node: <_ast.Num object at 0x7fd6cd360a10>` error) - not causing build process to stop and cause unexpected results