### PR TITLE
Improves portability by replacing symbol __linux__ with __unix__

### DIFF
--- a/ASCOfficeXlsFile2/source/XlsFormat/Auxiliary/HelpFunc.cpp
+++ b/ASCOfficeXlsFile2/source/XlsFormat/Auxiliary/HelpFunc.cpp
@@ -346,7 +346,7 @@ const std::wstring unescape_ST_Xstring(const std::wstring& wstr)
 
     while(true)
 	{
-#if defined(__linux__) || defined(_MAC)
+#if defined(__unix__) || defined(_MAC)
 		const auto it_range = boost::make_iterator_range(x_pos_noncopied, wstr_end);
         x_pos_next = boost::algorithm::find_first(it_range, L"_x").begin();
 #else

--- a/Common/DocxFormat/Source/Base/Types_32.h
+++ b/Common/DocxFormat/Source/Base/Types_32.h
@@ -45,7 +45,7 @@
         typedef uint16_t            _UINT16;
         typedef uint32_t            _UINT32;
         typedef uint64_t            _UINT64;
-#elif __APPLE__
+#elif defined(__APPLE__) || defined(__unix__)
 #include "stdint.h"
         typedef int16_t             _INT16;
         typedef int32_t             _INT32;

--- a/DesktopEditor/agg-2.4/include/agg_span_hatch.h
+++ b/DesktopEditor/agg-2.4/include/agg_span_hatch.h
@@ -6,6 +6,7 @@
 #include "agg_math.h"
 #include "agg_array.h"
 #include "agg_trans_affine.h"
+#include "agg_span_gradient.h" // _hypot 
 
 namespace agg
 {

--- a/DesktopEditor/common/Directory.h
+++ b/DesktopEditor/common/Directory.h
@@ -42,7 +42,7 @@
     #include "windef.h"
     #include <shlobj.h>
     #include <Rpc.h>
-#elif __linux__
+#elif __unix__
     #include <sys/types.h>
     #include <sys/stat.h>
     #include <unistd.h>
@@ -316,7 +316,7 @@ namespace NSDirectory
 #if defined(_WIN32) || defined (_WIN64)
 		DWORD dwAttrib = ::GetFileAttributesW(strDirectory.c_str());
 		return (dwAttrib != INVALID_FILE_ATTRIBUTES && 0 != (dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
-#elif __linux__
+#elif __unix__
         BYTE* pUtf8 = NULL;
         LONG lLen = 0;
         NSFile::CUtf8Converter::GetUtf8StringFromUnicode(strDirectory.c_str(), strDirectory.length(), pUtf8, lLen, false);

--- a/DesktopEditor/common/File.h
+++ b/DesktopEditor/common/File.h
@@ -48,7 +48,7 @@
 #define U_TO_UTF8(val) NSFile::CUtf8Converter::GetUtf8StringFromUnicode2(val.c_str(), (LONG)val.length())
 #define UTF8_TO_U(val) NSFile::CUtf8Converter::GetUnicodeStringFromUTF8((BYTE*)val.c_str(), (LONG)val.length())
 
-#if defined(__linux__) || defined(_MAC) && !defined(_IOS)
+#if defined(__unix__) || defined(_MAC) && !defined(_IOS)
 #include <unistd.h>
 #include <string.h>
 #endif
@@ -1160,7 +1160,7 @@ namespace NSFile
         return std::wstring(buf);
 #endif
 
-#if defined(__linux__) || defined(_MAC) && !defined(_IOS)
+#if defined(__unix__) || defined(_MAC) && !defined(_IOS)
         char buf[NS_FILE_MAX_PATH];
         memset(buf, 0, NS_FILE_MAX_PATH);
         if (readlink ("/proc/self/exe", buf, NS_FILE_MAX_PATH) <= 0)

--- a/DesktopEditor/common/Types.h
+++ b/DesktopEditor/common/Types.h
@@ -75,7 +75,7 @@ typedef int				INT;
 typedef unsigned int	UINT, *PUINT;
 typedef wchar_t			WCHAR;
 
-#ifdef __linux__
+#ifdef __unix__
 #include <inttypes.h>
 typedef int64_t     T_LONG64;
 typedef uint64_t    T_ULONG64;

--- a/DesktopEditor/cximage/CxImage/ximainfo.cpp
+++ b/DesktopEditor/cximage/CxImage/ximainfo.cpp
@@ -5,7 +5,7 @@
 
 #include "ximage.h"
 
-#if defined(_LINUX) || defined(__APPLE__)
+#if defined(__unix__) || defined(__APPLE__)
     #ifdef UNICODE
         #define _tcsnicmp(a,b,c) wcscasecmp(a,b)
     #else

--- a/DesktopEditor/cximage/raw/libdcr.h
+++ b/DesktopEditor/cximage/raw/libdcr.h
@@ -42,7 +42,7 @@
  #include <sys/types.h>
 #endif
 
-#if defined(_LINUX) || defined(__APPLE__)
+#if defined(__unix__) || defined(__APPLE__)
  #include <setjmp.h>
  #include <sys/types.h>
  #define _swab   swab

--- a/DesktopEditor/cximage/tiff/tif_config.h
+++ b/DesktopEditor/cximage/tiff/tif_config.h
@@ -35,7 +35,7 @@
 /* The size of a `long', as computed by sizeof. */
 #define SIZEOF_LONG 4
 
-#ifndef _LINUX
+#ifndef __unix__
 /* Signed 64-bit type */
 #define TIFF_INT64_T signed __int64
 
@@ -43,7 +43,7 @@
 #define TIFF_UINT64_T unsigned __int64
 #endif
 
-#ifdef _LINUX
+#ifdef __unix__
 #include <inttypes.h>
 
 /* Signed 64-bit type */

--- a/DjVuFile/libdjvu/ByteStream.cpp
+++ b/DjVuFile/libdjvu/ByteStream.cpp
@@ -81,13 +81,13 @@
 # include <io.h>
 #endif
 
-#ifdef UNIX
+#ifdef __unix__
 # ifndef HAS_MEMMAP
 #  define HAS_MEMMAP 1
 # endif
 #endif
 
-#ifdef UNIX
+#ifdef __unix__
 # include <sys/types.h>
 # include <sys/stat.h>
 # include <unistd.h>
@@ -98,7 +98,7 @@
 #endif
 
 #ifdef macintosh
-# ifndef UNIX
+# ifndef __unix__
 #  include <unistd.h>
 _MSL_IMP_EXP_C int _dup(int);
 _MSL_IMP_EXP_C int _dup2(int,int);
@@ -673,13 +673,13 @@ urlfopen(const GURL &url,const char mode[])
 #endif
 }
 
-#ifdef UNIX
+#ifdef __unix__
 static int
 urlopen(const GURL &url, const int mode, const int perm)
 {
   return open((const char *)url.NativeFilename(),mode,perm);
 }
-#endif /* UNIX */
+#endif /* __unix__ */
 
 GUTF8String
 ByteStream::Stdio::init(const GURL &url, const char mode[])
@@ -1006,7 +1006,7 @@ ByteStream::create(const GURL &url,char const * const xmode)
 {
   GP<ByteStream> retval;
   const char *mode = ((xmode) ? xmode : "rb");
-#ifdef UNIX
+#ifdef __unix__
   if (!strcmp(mode,"rb")) 
     {
       int fd = urlopen(url,O_RDONLY,0777);

--- a/HtmlFile/HtmlFile.cpp
+++ b/HtmlFile/HtmlFile.cpp
@@ -40,7 +40,7 @@
 #include <vector>
 #include <map>
 
-#ifdef LINUX
+#ifdef __unix__
 #include <unistd.h>
 #include <sys/wait.h>
 #include <stdio.h>
@@ -359,7 +359,7 @@ int CHtmlFile::Convert(const std::vector<std::wstring>& arFiles, const std::wstr
     NSFile::CFileBinary::Remove(sTempFileForParams);
 #endif
 
-#ifdef LINUX
+#ifdef __unix__
     std::wstring sTempFileForParams = NSFile::CFileBinary::CreateTempFileWithUniqueName(NSFile::CFileBinary::GetTempPath(), L"XML");
     NSFile::CFileBinary oFile;
     oFile.CreateFileW(sTempFileForParams);

--- a/OfficeUtils/src/zlib-1.2.3/contrib/minizip/miniunz.c
+++ b/OfficeUtils/src/zlib-1.2.3/contrib/minizip/miniunz.c
@@ -13,7 +13,7 @@
 #include <errno.h>
 #include <fcntl.h>
 
-#if defined(unix) || defined(_LINUX) 
+#if defined(unix) || defined(_LINUX) || defined(__unix__)
 # include <unistd.h>
 # include <utime.h>
 #else

--- a/OfficeUtils/src/zlib-1.2.3/contrib/minizip/minizip.c
+++ b/OfficeUtils/src/zlib-1.2.3/contrib/minizip/minizip.c
@@ -12,7 +12,7 @@
 #include <errno.h>
 #include <fcntl.h>
 
-#if defined(unix) || defined(_LINUX) 
+#if defined(unix) || defined(__unix__) 
 # include <unistd.h>
 # include <utime.h>
 # include <sys/types.h>

--- a/PdfWriter/Src/Types.h
+++ b/PdfWriter/Src/Types.h
@@ -46,7 +46,7 @@
 #include <algorithm>
 #include <math.h>
 
-#ifdef __linux__
+#ifdef __unix__
 #include <string.h>
 #endif
 


### PR DESCRIPTION
In the process of helping with ONLYOFFICE/DocumentServer#221