### PR TITLE
Add --no-historyt to `gclient-sync`

### DIFF
--- a/Common/3dParty/v8/fetch.bat
+++ b/Common/3dParty/v8/fetch.bat
@@ -23,4 +23,4 @@ cd v8
 call git checkout -b 6.0 -t branch-heads/6.0
 cd ../
 
-call gclient sync
+call gclient sync --no-history

--- a/Common/3dParty/v8/fetch.sh
+++ b/Common/3dParty/v8/fetch.sh
@@ -22,7 +22,7 @@ else
 cd v8
 fi
 
-gclient sync
+gclient sync --no-history
 
 os=$(uname -s)
 platform=""

--- a/Common/3dParty/v8/fetch_linux_correct.sh
+++ b/Common/3dParty/v8/fetch_linux_correct.sh
@@ -13,7 +13,7 @@ if [ -d "$SCRIPTPATH/v8/third_party/binutils/Linux_ia32/Release" ]; then
 fi
 
 cd "$SCRIPTPATH/v8"
-gclient sync
+gclient sync --no-history
 
 if [ -d "$SCRIPTPATH/v8/third_party/binutils/Linux_x64/Release/bin" ]; then
 cd "$SCRIPTPATH/v8/third_party/binutils/Linux_x64/Release/bin"


### PR DESCRIPTION
Greatly reduce time to fetch v8 sources.
Time to execute `gclient-sync`
Default varinant `real    21m2.279s`
With `--no-history` - `real    0m53.638s`