### PR TITLE
Add workaround for building icu on ArchLinux

### DIFF
--- a/Common/3dParty/icu/fetch.sh
+++ b/Common/3dParty/icu/fetch.sh
@@ -59,6 +59,13 @@ else
   svn export http://source.icu-project.org/repos/icu/tags/release-$ICU_MAJOR_VER-$ICU_MINOR_VER/icu4c ./icu
 fi
 
+# Workaround for building icu older than 60.0 on Archlinux
+# See https://bugs.archlinux.org/task/55246
+if [ -f "/etc/arch-release" ]; then
+  echo "Arch Linux detected. Applying 'xlocale.h' error patch"
+  sed -i 's/xlocale/locale/' ./icu/source/i18n/digitlst.cpp
+fi
+
 cd ./icu/source/
 
 if [ ! -f "./Makefile" ]


### PR DESCRIPTION
See https://bugs.archlinux.org/task/55246
`digitlst.cpp:67:13: fatal error: 'xlocale.h' file not found`