### PR TITLE
Fix possible typo

### DIFF
--- a/Common/3dParty/cef/fetch.sh
+++ b/Common/3dParty/cef/fetch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT=$(readlink -n "$0" || grealpath "$0")
+SCRIPT=$(readlink -f "$0" || grealpath "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
 
 os=$(uname -s)


### PR DESCRIPTION
`realink -n` return empty string
Introduced in
https://github.com/ONLYOFFICE/core/commit/51569b626fc38c66d4dbc98c60d8f21d88d2332b
Seems have nothing to do with mac, since all other file has `readlink -f`