### PR TITLE
Ignore -no-warrowing warning while building PdfWriter

### DIFF
--- a/PdfWriter/PdfWriter.pro
+++ b/PdfWriter/PdfWriter.pro
@@ -22,6 +22,10 @@ LIBS += -lCryptoPPLib
 
 DEFINES += NOMINMAX
 
+core_linux {
+    QMAKE_CXXFLAGS += -Wno-narrowing
+}
+
 core_windows {
     DEFINES -= UNICODE
     DEFINES -= _UNICODE


### PR DESCRIPTION
Errors looks like:
`../Src/ICCProfile.h:52: error: narrowing conversion of '-72' from 'int'
to 'unsigned char' inside { } [-Wnarrowing]`