### PR TITLE
Fix building libicu on all glibc >= 2.26 systems

### DIFF
--- a/Common/3dParty/icu/fetch.sh
+++ b/Common/3dParty/icu/fetch.sh
@@ -59,12 +59,11 @@ else
   svn export http://source.icu-project.org/repos/icu/tags/release-$ICU_MAJOR_VER-$ICU_MINOR_VER/icu4c ./icu
 fi
 
-# Workaround for building icu older than 60.0 on Archlinux
+# Workaround for building icu older than 60.0
+# on systems without xlocale.h (removed from glibc since 2.26)
+# See https://sourceware.org/glibc/wiki/Release/2.26#Removal_of_.27xlocale.h.27
 # See https://bugs.archlinux.org/task/55246
-if [ -f "/etc/arch-release" ]; then
-  echo "Arch Linux detected. Applying 'xlocale.h' error patch"
-  sed -i 's/xlocale/locale/' ./icu/source/i18n/digitlst.cpp
-fi
+sed -i 's/xlocale/locale/' ./icu/source/i18n/digitlst.cpp
 
 cd ./icu/source/
 


### PR DESCRIPTION
Checked this variant works on glibc 2.27 system (Ubuntu 18.04) and glibc 2.19 system (Ubuntu 14.04)