### PR TITLE
Fix empty files

### DIFF
--- a/EpubFile/src/CBookItem.cpp
+++ b/EpubFile/src/CBookItem.cpp
@@ -30,6 +30,12 @@ bool CBookItem::ReadItem(XmlUtils::CXmlLiteReader& oXmlLiteReader, int depth)
 
         if (sAttributeName == L"href")
         {
+            size_t nPer20 = sAttributeValue.find(L"%20");
+            while(nPer20 != std::wstring::npos)
+            {
+                sAttributeValue.replace(nPer20, 3, L" ");
+                nPer20 = sAttributeValue.find(L"%20");
+            }
             size_t posLastSlash = sAttributeValue.rfind(L'/');
             m_sRef = posLastSlash == std::wstring::npos ? sAttributeValue : sAttributeValue.substr(posLastSlash + 1);
         }

--- a/EpubFile/src/CEpubFile.cpp
+++ b/EpubFile/src/CEpubFile.cpp
@@ -67,6 +67,9 @@ HRESULT CEpubFile::Convert(const std::wstring& sInputFile, const std::wstring& s
         while (oXmlLiteReader.ReadNextSiblingNode(nParentDepth))
         {
             std::wstring sName = oXmlLiteReader.GetName();
+            size_t nDot = sName.find(L':');
+            if(nDot != std::wstring::npos)
+                sName.erase(0, nDot + 1);
             if (sName == L"metadata")
             {
                 m_oBookInfo.ReadInfo(oXmlLiteReader);


### PR DESCRIPTION
In content.opf, 1681_978-80-7384-542-1_Ve stinu sestry.epub have file names that have, for some reason, %20 instead of spaces.
And in content.opf of vislockaya_mihalina_iskusstvo_lyubvi.epub, all tags had prefixes.