### PR TITLE
[UPD] update function to v8 version 8.7.220.23

### DIFF
--- a/DesktopEditor/doctrenderer/memorystream.cpp
+++ b/DesktopEditor/doctrenderer/memorystream.cpp
@@ -126,7 +126,7 @@ v8::Handle<v8::ObjectTemplate> CreateMemoryStreamTemplate(v8::Isolate* isolate)
     v8::Isolate* current = v8::Isolate::GetCurrent();
 
     // property
-    result->SetAccessor(v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), "pos"), _ms_pos); // получить код ошибки
+    result->SetAccessor(v8::String::NewFromUtf8Literal(v8::Isolate::GetCurrent(), "pos"), _ms_pos); // получить код ошибки
 
     // прописываем функции - методы объекта
     result->Set(current, "Copy",			v8::FunctionTemplate::New(current, _ms_copy));


### PR DESCRIPTION
Still one error remaining at line 97:
memorystream.cpp:97:69: error: too few arguments to function call, single argument
      'context' was not specified
    CMemoryStream* pNative2 = unwrap_memorystream(args[0]->ToObject());
                                                  ~~~~~~~~~~~~~~~~~ ^
/usr/local/include/node/v8.h:2822:3: note: 'ToObject' declared here
  V8_WARN_UNUSED_RESULT MaybeLocal<Object> ToObject(
  ^
/usr/local/include/node/v8config.h:431:31: note: expanded from macro
      'V8_WARN_UNUSED_RESULT'
#define V8_WARN_UNUSED_RESULT __attribute__((warn_unused_result))

I'm pretty sure @K0R0L would find the solution easily (according to how good his previous modifications are) but unfortunately, I'm haven't found the solution yet...