### PR TITLE
Node14adaptation: cleanup memorystream.cpp/h files

### DIFF
--- a/DesktopEditor/doctrenderer/memorystream.cpp
+++ b/DesktopEditor/doctrenderer/memorystream.cpp
@@ -93,8 +93,8 @@ void _ms_writestring2(const v8::FunctionCallbackInfo<v8::Value>& args)
 void _ms_copy(const v8::FunctionCallbackInfo<v8::Value>& args)
 {
     CMemoryStream* pNative = unwrap_memorystream(args.This());
+    CMemoryStream* pNative2 = unwrap_memorystream(CV8Convert::unwrap<v8::Object>(args[0]->ToObject(v8::Isolate::GetCurrent()->GetCurrentContext())));
 
-    CMemoryStream* pNative2 = unwrap_memorystream(args[0]->ToObject());
     size_t pos = (size_t)CV8Convert::ToUint(args[1]);
     size_t len = (size_t)CV8Convert::ToUint(args[2]);
 

--- a/DesktopEditor/doctrenderer/memorystream.h
+++ b/DesktopEditor/doctrenderer/memorystream.h
@@ -88,6 +88,10 @@ public:
 	{
 		return ToString(m->Get());
 	}
+	template <typename T>
+        inline static v8::Local<T> unwrap(v8::MaybeLocal<T> maybe) {
+                return maybe.FromMaybe(v8::Local<T>());
+        }
 };
 
 class CMemoryStream


### PR DESCRIPTION
other errors are still comming, in other files. To continue.