### PR TITLE
Fix bug 55177

### DIFF
--- a/PdfReader/PdfReader.cpp
+++ b/PdfReader/PdfReader.cpp
@@ -229,6 +229,9 @@ namespace PdfReader
         if (!m_pInternal->m_pPDFDocument)
             return m_eError;
 
+        if (m_pInternal->m_pPDFDocument->isOk())
+            return 0;
+
         return m_pInternal->m_pPDFDocument->getErrorCode();
 	}
     int CPdfReader::GetPagesCount()


### PR DESCRIPTION
xpdf itself tries to handle the error and if it succeeds, then isOk will be gTrue