### PR TITLE
Improvements to the libvlc player widget and its example

### DIFF
--- a/Common/3dParty/libvlc/test/player.cpp
+++ b/Common/3dParty/libvlc/test/player.cpp
@@ -75,9 +75,7 @@ void Mwindow::initUI()
 	QObject::connect(slider, SIGNAL(sliderMoved(int)), this, SLOT(changePosition(int)));
 
 	/* A timer to update the sliders */
-	QTimer *timer = new QTimer(this);
-	connect(timer, SIGNAL(timeout()), this, SLOT(updateInterface()));
-	timer->start(100);
+	connect(vlcPlayer, SIGNAL(positionChanged(float)), this, SLOT(updateInterface(float)));
 
 	/* Central Widgets */
 	QWidget *centralWidget = new QWidget;
@@ -135,16 +133,16 @@ void Mwindow::play()
 	if (!vlcPlayer)
 		return;
 
-	if (libvlc_media_player_is_playing(vlcPlayer->m_pVlcPlayer))
+	if (vlcPlayer->isPlaying())
 	{
 		/* Pause */
-		libvlc_media_player_pause(vlcPlayer->m_pVlcPlayer);
+		vlcPlayer->pause();
 		playBut->setText("Play");
 	}
 	else
 	{
 		/* Play again */
-		libvlc_media_player_play(vlcPlayer->m_pVlcPlayer);
+		vlcPlayer->play();
 		playBut->setText("Pause");
 	}
 }
@@ -158,21 +156,18 @@ int Mwindow::changeVolume(int vol)
 
 void Mwindow::changePosition(int pos)
 { /* Called on position slider change */
-
-	libvlc_media_player_set_position(vlcPlayer->m_pVlcPlayer, (float)pos / 1000.0);
+	vlcPlayer->setPosition(static_cast<float>(pos) / 1000.0);
 }
 
-void Mwindow::updateInterface()
+void Mwindow::updateInterface(float fNewPos)
 { // Update interface and check if song is finished
-
 	if (!vlcPlayer)
 		return;
 
 	/* update the timeline */
-	float pos = libvlc_media_player_get_position(vlcPlayer->m_pVlcPlayer);
-	slider->setValue((int)(pos * 1000.0));
+	slider->setValue(static_cast<int>(fNewPos * 1000.0));
 
-	/* Stop the media */
+	/* Stop the media if needed */
 	if (vlcPlayer->getState() == libvlc_Ended)
 		this->stop();
 }

--- a/Common/3dParty/libvlc/test/player.h
+++ b/Common/3dParty/libvlc/test/player.h
@@ -26,7 +26,7 @@ private slots:
 
 	int changeVolume(int);
 	void changePosition(int);
-	void updateInterface();
+	void updateInterface(float);
 
 protected:
 	virtual void closeEvent(QCloseEvent *);

--- a/Common/3dParty/libvlc/vlcplayer.cpp
+++ b/Common/3dParty/libvlc/vlcplayer.cpp
@@ -5,7 +5,7 @@
 CVlcPlayer::CVlcPlayer(QWidget* parent) : QWidget(parent)
 {
 	// initialize libVLC
-	m_pVlcInstance = libvlc_new(0, NULL);
+		m_pVlcInstance = libvlc_new(0, NULL);
 	// error if libvlc instantiation was unsuccessful
 	if (m_pVlcInstance == nullptr)
 	{
@@ -13,7 +13,7 @@ CVlcPlayer::CVlcPlayer(QWidget* parent) : QWidget(parent)
 		exit(1);
 	}
 	// initialize vlc media player
-	m_pVlcPlayer = libvlc_media_player_new(m_pVlcInstance);
+		m_pVlcPlayer = libvlc_media_player_new(m_pVlcInstance);
 	// disable event handling by vlc internals
 	libvlc_video_set_mouse_input(m_pVlcPlayer, false);
 	libvlc_video_set_key_input(m_pVlcPlayer, false);
@@ -30,10 +30,10 @@ CVlcPlayer::CVlcPlayer(QWidget* parent) : QWidget(parent)
 
 CVlcPlayer::~CVlcPlayer()
 {
+	if (m_pVlcPlayer)
+			libvlc_media_player_release(m_pVlcPlayer);
 	if (m_pVlcInstance)
 		libvlc_release(m_pVlcInstance);
-	if (m_pVlcPlayer)
-		libvlc_media_player_release(m_pVlcPlayer);
 }
 
 void CVlcPlayer::onStateChanged(const libvlc_event_t* pEvent, void* pData)

--- a/Common/3dParty/libvlc/vlcplayer.cpp
+++ b/Common/3dParty/libvlc/vlcplayer.cpp
@@ -5,7 +5,7 @@
 CVlcPlayer::CVlcPlayer(QWidget* parent) : QWidget(parent)
 {
 	// initialize libVLC
-		m_pVlcInstance = libvlc_new(0, NULL);
+	m_pVlcInstance = libvlc_new(0, NULL);
 	// error if libvlc instantiation was unsuccessful
 	if (m_pVlcInstance == nullptr)
 	{
@@ -13,7 +13,7 @@ CVlcPlayer::CVlcPlayer(QWidget* parent) : QWidget(parent)
 		exit(1);
 	}
 	// initialize vlc media player
-		m_pVlcPlayer = libvlc_media_player_new(m_pVlcInstance);
+	m_pVlcPlayer = libvlc_media_player_new(m_pVlcInstance);
 	// disable event handling by vlc internals
 	libvlc_video_set_mouse_input(m_pVlcPlayer, false);
 	libvlc_video_set_key_input(m_pVlcPlayer, false);
@@ -26,6 +26,7 @@ CVlcPlayer::CVlcPlayer(QWidget* parent) : QWidget(parent)
 		libvlc_event_attach(m_pEventManager, nEvent, onStateChanged, this);
 	}
 	libvlc_event_attach(m_pEventManager, libvlc_MediaPlayerTimeChanged , onTimeChanged, this);
+	libvlc_event_attach(m_pEventManager, libvlc_MediaPlayerPositionChanged , onPositionChanged, this);
 }
 
 CVlcPlayer::~CVlcPlayer()
@@ -46,6 +47,12 @@ void CVlcPlayer::onTimeChanged(const libvlc_event_t* pEvent, void* pData)
 {
 	CVlcPlayer* pVlcPlayer = reinterpret_cast<CVlcPlayer*>(pData);
 	emit pVlcPlayer->timeChanged(pEvent->u.media_player_time_changed.new_time);
+}
+
+void CVlcPlayer::onPositionChanged(const libvlc_event_t* pEvent, void* pData)
+{
+	CVlcPlayer* pVlcPlayer = reinterpret_cast<CVlcPlayer*>(pData);
+	emit pVlcPlayer->positionChanged(pEvent->u.media_player_position_changed.new_position);
 }
 
 void CVlcPlayer::integrateIntoWidget(QWidget* pWidget)
@@ -95,14 +102,24 @@ void CVlcPlayer::setVolume(int nVolume)
 	libvlc_audio_set_volume(m_pVlcPlayer, nVolume);
 }
 
-void CVlcPlayer::setTime(int nTime)
+void CVlcPlayer::setTime(qint64 nTime)
 {
 	libvlc_media_player_set_time(m_pVlcPlayer, nTime);
+}
+
+void CVlcPlayer::setPosition(float fPos)
+{
+	libvlc_media_player_set_position(m_pVlcPlayer, fPos);
 }
 
 bool CVlcPlayer::isAudio()
 {
 	return !libvlc_media_player_has_vout(m_pVlcPlayer);
+}
+
+bool CVlcPlayer::isPlaying()
+{
+	return libvlc_media_player_is_playing(m_pVlcPlayer);
 }
 
 libvlc_state_t CVlcPlayer::getState()

--- a/Common/3dParty/libvlc/vlcplayer.h
+++ b/Common/3dParty/libvlc/vlcplayer.h
@@ -16,8 +16,9 @@ public:
 
 public:
 	// libvlc event callbacks
-	static void onStateChanged(const libvlc_event_t *pEvent, void *pData);
-	static void onTimeChanged(const libvlc_event_t *pEvent, void *pData);
+	static void onStateChanged(const libvlc_event_t* pEvent, void *pData);
+	static void onTimeChanged(const libvlc_event_t* pEvent, void *pData);
+	static void onPositionChanged(const libvlc_event_t* pEvent, void *pData);
 
 public:
 	void integrateIntoWidget(QWidget* pWidget);
@@ -26,13 +27,16 @@ public:
 	void play();
 	void stop();
 	void setVolume(int nVolume);
-	void setTime(int nTime);
+	void setTime(qint64 nTime);
+	void setPosition(float fPos);
 	bool isAudio();
+	bool isPlaying();
 	libvlc_state_t getState();
 
 signals:
 	void stateChanged(int newState);
 	void timeChanged(qint64 nNewTime);
+	void positionChanged(float fNewPos);
 
 public:
 	libvlc_instance_t* m_pVlcInstance;


### PR DESCRIPTION
+ Fixed the order in which libvlc resources are released
+ Added `positionChanged` signal to `CVlcPlayer`
+ Some refactoring in liblvc player example to make it use only `CVlcPlayer` methods