### PR TITLE
JSON: Simplification of working with strings

### DIFF
--- a/DesktopEditor/doctrenderer/json/json.cpp
+++ b/DesktopEditor/doctrenderer/json/json.cpp
@@ -66,16 +66,13 @@ namespace NSJSON
 				static_cast<CPrimitive*>(m_internal->m_value.get())->isDouble());
 	}
 
-	bool IValue::IsStringA() const
+	bool IValue::IsString() const
 	{
-		return (m_internal->m_type == CTypedValue::vtPrimitive &&
-				static_cast<CPrimitive*>(m_internal->m_value.get())->isStringA());
-	}
+		if (m_internal->m_type != CTypedValue::vtPrimitive)
+			return false;
 
-	bool IValue::IsStringW() const
-	{
-		return (m_internal->m_type == CTypedValue::vtPrimitive &&
-				static_cast<CPrimitive*>(m_internal->m_value.get())->isStringW());
+		CPrimitive* pPrimitive = static_cast<CPrimitive*>(m_internal->m_value.get());
+		return (pPrimitive->isStringA() || pPrimitive->isStringW());
 	}
 
 	bool IValue::IsArray() const

--- a/DesktopEditor/doctrenderer/json/json.h
+++ b/DesktopEditor/doctrenderer/json/json.h
@@ -73,11 +73,7 @@ namespace NSJSON
 		/**
 		 * Returns true if the value is a string.
 		 */
-		bool IsStringA() const;
-		/**
-		 * Returns true if the value is a wstring.
-		 */
-		bool IsStringW() const;
+		bool IsString() const;
 		/**
 		 * Returns true if the value is an array.
 		 */

--- a/DesktopEditor/doctrenderer/json/json_values.cpp
+++ b/DesktopEditor/doctrenderer/json/json_values.cpp
@@ -1,7 +1,7 @@
 #include "json_values.h"
 
-#include <locale>
-#include <codecvt>
+// for string <=> wstring conversion
+#include "../../common/File.h"
 
 namespace NSJSON
 {
@@ -119,8 +119,7 @@ namespace NSJSON
 
 		if (m_type == ptStringW)
 		{
-			std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-			return std::string(converter.to_bytes(m_wstring));
+			return U_TO_UTF8(m_wstring);
 		}
 
 #ifdef JSON_DEBUG
@@ -136,8 +135,7 @@ namespace NSJSON
 
 		if (m_type == ptStringA)
 		{
-			std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-			return std::wstring(converter.from_bytes(m_string));
+			return UTF8_TO_U(m_string);
 		}
 
 #ifdef JSON_DEBUG

--- a/DesktopEditor/doctrenderer/json/json_values.cpp
+++ b/DesktopEditor/doctrenderer/json/json_values.cpp
@@ -1,5 +1,8 @@
 #include "json_values.h"
 
+#include <locale>
+#include <codecvt>
+
 namespace NSJSON
 {
 	IBaseValue::IBaseValue()
@@ -113,6 +116,13 @@ namespace NSJSON
 	{
 		if (m_type == ptStringA)
 			return m_string;
+
+		if (m_type == ptStringW)
+		{
+			std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+			return std::string(converter.to_bytes(m_wstring));
+		}
+
 #ifdef JSON_DEBUG
 		throw std::bad_cast();
 #endif
@@ -123,6 +133,13 @@ namespace NSJSON
 	{
 		if (m_type == ptStringW)
 			return m_wstring;
+
+		if (m_type == ptStringA)
+		{
+			std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+			return std::wstring(converter.from_bytes(m_string));
+		}
+
 #ifdef JSON_DEBUG
 		throw std::bad_cast();
 #endif

--- a/DesktopEditor/doctrenderer/json/serialization.h
+++ b/DesktopEditor/doctrenderer/json/serialization.h
@@ -29,13 +29,9 @@ namespace NSJSON
 		{
 			ret = NSJSBase::CJSContext::createDouble((double)value);
 		}
-		else if (value.IsStringA())
+		else if (value.IsString())
 		{
-			ret = NSJSBase::CJSContext::createString((std::string)value);
-		}
-		else if (value.IsStringW())
-		{
-			ret = NSJSBase::CJSContext::createString((std::wstring)value);
+			ret = NSJSBase::CJSContext::createString(value.ToStringA());
 		}
 		// arrays
 		else if (value.IsArray())

--- a/DesktopEditor/doctrenderer/test/json/main.cpp
+++ b/DesktopEditor/doctrenderer/test/json/main.cpp
@@ -180,32 +180,18 @@ public:
 						return false;
 				}
 			}
-			else if (value.IsStringA())
-			{
-				if (makeExpects)
-					EXPECT_TRUE(jsValue->isString());
-				if (!jsValue->isString())
-					return false;
-
-				std::string val = value.ToStringA();
-				std::string jsVal = jsValue->toStringA();
-				if (makeExpects)
-					EXPECT_EQ(val, jsVal);
-				if (val != jsVal)
-					return false;
-			}
 			else
 			{
 				if (makeExpects)
 				{
-					EXPECT_TRUE(value.IsStringW());
+					EXPECT_TRUE(value.IsString());
 					EXPECT_TRUE(jsValue->isString());
 				}
 				if (!jsValue->isString())
 					return false;
 
-				std::wstring val = value.ToStringW();
-				std::wstring jsVal = jsValue->toStringW();
+				std::string val = value.ToStringA();
+				std::string jsVal = jsValue->toStringA();
 				if (makeExpects)
 					EXPECT_EQ(val, jsVal);
 				if (val != jsVal)
@@ -569,10 +555,10 @@ TEST_F(CJSONTest, wrong_usage)
 	EXPECT_EQ((bool)val, false);
 	EXPECT_EQ((int)val, 0);
 	EXPECT_EQ((double)val, 0.0);
-	EXPECT_EQ((std::wstring)val, L"");
+	EXPECT_EQ((std::wstring)val, L"test");
 #endif
 
-	val = L"тест";
+	val = L"test";
 #ifdef JSON_DEBUG
 	EXPECT_THROW((bool)val, std::bad_cast);
 	EXPECT_THROW((int)val, std::bad_cast);
@@ -582,7 +568,7 @@ TEST_F(CJSONTest, wrong_usage)
 	EXPECT_EQ((bool)val, false);
 	EXPECT_EQ((int)val, 0);
 	EXPECT_EQ((double)val, 0.0);
-	EXPECT_EQ((std::string)val, "");
+	EXPECT_EQ((std::string)val, "test");
 #endif
 
 	val = CValue::CreateObject();

--- a/DesktopEditor/doctrenderer/test/json/main.cpp
+++ b/DesktopEditor/doctrenderer/test/json/main.cpp
@@ -550,26 +550,24 @@ TEST_F(CJSONTest, wrong_usage)
 	EXPECT_THROW((bool)val, std::bad_cast);
 	EXPECT_THROW((int)val, std::bad_cast);
 	EXPECT_THROW((double)val, std::bad_cast);
-	EXPECT_THROW((std::wstring)val, std::bad_cast);
 #else
 	EXPECT_EQ((bool)val, false);
 	EXPECT_EQ((int)val, 0);
 	EXPECT_EQ((double)val, 0.0);
-	EXPECT_EQ((std::wstring)val, L"test");
 #endif
+	EXPECT_EQ((std::wstring)val, L"test");
 
 	val = L"test";
 #ifdef JSON_DEBUG
 	EXPECT_THROW((bool)val, std::bad_cast);
 	EXPECT_THROW((int)val, std::bad_cast);
 	EXPECT_THROW((double)val, std::bad_cast);
-	EXPECT_THROW((std::string)val, std::bad_cast);
 #else
 	EXPECT_EQ((bool)val, false);
 	EXPECT_EQ((int)val, 0);
 	EXPECT_EQ((double)val, 0.0);
-	EXPECT_EQ((std::string)val, "test");
 #endif
+	EXPECT_EQ((std::string)val, "test");
 
 	val = CValue::CreateObject();
 #ifdef JSON_DEBUG


### PR DESCRIPTION
 - Combined `IsStringA()` and `IsStringW()` to `IsString()`.
 - Conversion functions `ToStringA()` and `ToStringW()` now works with both types of strings.
 - Fixed tests.