### PR TITLE
doctrenderer: make sure printf always uses a format string

### DIFF
--- a/DesktopEditor/doctrenderer/docbuilder_p.h
+++ b/DesktopEditor/doctrenderer/docbuilder_p.h
@@ -1400,7 +1400,7 @@ namespace NSDoctRenderer
 			FILE* pFile = oFile.OpenFileNative(sFile, append ? L"a+" : L"a");
 			if (pFile)
 			{
-				fprintf(pFile, sValueA.c_str());
+				fprintf(pFile, "%s", sValueA.c_str());
 				fclose(pFile);
 			}
 		}

--- a/DesktopEditor/doctrenderer/js_internal/js_logger.cpp
+++ b/DesktopEditor/doctrenderer/js_internal/js_logger.cpp
@@ -21,7 +21,7 @@ namespace NSJSBase
 
 		if (g_logger_file.length() == 1)
 		{
-			printf(details);
+			printf("%s", details);
 			printf(": %d\n", (int)(dwCur - g_logger_time));
 		}
 		else

--- a/DesktopEditor/doctrenderer/nativecontrol.h
+++ b/DesktopEditor/doctrenderer/nativecontrol.h
@@ -426,7 +426,7 @@ namespace NSNativeControl
 				if (NULL != _file)
 				{
 					fprintf(_file, "\"");
-					fprintf(_file, sParam.c_str());
+					fprintf(_file, "%s", sParam.c_str());
 					fprintf(_file, "\",");
 					fclose(_file);
 				}


### PR DESCRIPTION
Passing the string that is to be printed as the format string could lead to trouble when the string has sequences that would have meaning in a format string. Using the `"%s"` format string makes sure the string that is to be printed isn't interpreted as a format string.

This also makes compiling with `-Werror=format-security` happy.