### PR TITLE
Security Vulnerability - Action Required: EC2N::DecodePoint can crash if exponents are not in descending order

### DIFF
--- a/Common/3dParty/cryptopp/gf2n.cpp
+++ b/Common/3dParty/cryptopp/gf2n.cpp
@@ -135,6 +135,9 @@ PolynomialMod2 PolynomialMod2::Monomial(size_t i)
 
 PolynomialMod2 PolynomialMod2::Trinomial(size_t t0, size_t t1, size_t t2)
 {
+	CRYPTOPP_ASSERT(t0 > t1);
+	CRYPTOPP_ASSERT(t1 > t2);
+
 	PolynomialMod2 r((word)0, t0+1);
 	r.SetBit(t0);
 	r.SetBit(t1);
@@ -144,6 +147,11 @@ PolynomialMod2 PolynomialMod2::Trinomial(size_t t0, size_t t1, size_t t2)
 
 PolynomialMod2 PolynomialMod2::Pentanomial(size_t t0, size_t t1, size_t t2, size_t t3, size_t t4)
 {
+	CRYPTOPP_ASSERT(t0 > t1);
+	CRYPTOPP_ASSERT(t1 > t2);
+	CRYPTOPP_ASSERT(t2 > t3);
+	CRYPTOPP_ASSERT(t3 > t4);
+
 	PolynomialMod2 r((word)0, t0+1);
 	r.SetBit(t0);
 	r.SetBit(t1);


### PR DESCRIPTION
Hi, recently I found a security issue in the `PolynomialMod2 :: Trinomial` and `PolynomialMod2 :: Pentanomial` in the file of `Common/3dParty/cryptopp/gf2n.cpp`. It shares similarities to a recent CVE disclosure [CVE-2023-50980](https://nvd.nist.gov/vuln/detail/CVE-2023-50980) in the [cryptopp](https://github.com/weidai11/cryptopp). 
**The source vulnerability information is as follows:**

> Vulnerability Detail:
> CVE Identifier: CVE-2023-50980
> Description:gf2n.cpp in Crypto++ (aka cryptopp) through 8.9.0 allows attackers to cause a denial of service (application crash) via DER public-key data for an F(2^m) curve, if the degree of each term in the polynomial is not strictly decreasing.
> Reference: https://nvd.nist.gov/vuln/detail/CVE-2023-50980
> Patch: https://github.com/weidai11/cryptopp/commit/eb383b8e1622c07da2d5d6599a8b0e17a0deee0f

Would you help to check if this bug is true? If it's true, please reivew my pr. Thank you for your effort and patience! 
