### PR TITLE
fix building on debian OfficeFileFormatChecker2.cpp

### DIFF
--- a/Common/OfficeFileFormatChecker2.cpp
+++ b/Common/OfficeFileFormatChecker2.cpp
@@ -44,7 +44,7 @@
 
 #include "3dParty/pole/pole.h"
 #include <algorithm>
-
+#include <limits>
 #include "OfficeFileFormatDefines.h"
 
 #define MIN_SIZE_BUFFER 4096


### PR DESCRIPTION
fixing "std::numeric_limits<uint64_t>::max not declared" while compiling on debian