### PR TITLE
Add OpenSSL 3.x, V8 12.1+, GCC 15 compatibility and system library support

### DIFF
--- a/Common/3dParty/boost/boost.pri
+++ b/Common/3dParty/boost/boost.pri
@@ -1,53 +1,61 @@
-INCLUDEPATH += $$PWD/build/$$CORE_BUILDS_PLATFORM_PREFIX/include
-CORE_BOOST_LIBS = $$PWD/build/$$CORE_BUILDS_PLATFORM_PREFIX/lib
+!use_system_boost {
+    INCLUDEPATH += $$PWD/build/$$CORE_BUILDS_PLATFORM_PREFIX/include
+    CORE_BOOST_LIBS = $$PWD/build/$$CORE_BUILDS_PLATFORM_PREFIX/lib
+
+    core_android {
+        INCLUDEPATH += $$PWD/build/android/include
+        CORE_BOOST_LIBS = $$PWD/build/android/lib/$$CORE_BUILDS_PLATFORM_PREFIX
+
+        DEFINES += "_HAS_AUTO_PTR_ETC=0"
+    }
+
+    bundle_xcframeworks {
+        xcframework_platform_ios_simulator {
+            CORE_BOOST_LIBS = $$PWD/build/ios_xcframework/ios_simulator/lib/$$CORE_BUILDS_PLATFORM_PREFIX
+        } else {
+            CORE_BOOST_LIBS = $$PWD/build/ios_xcframework/ios/lib/$$CORE_BUILDS_PLATFORM_PREFIX
+        }
+    }
+}
 
 core_ios:CONFIG += disable_enum_constexpr_conversion
 core_android:CONFIG += disable_enum_constexpr_conversion
 core_mac:CONFIG += disable_enum_constexpr_conversion
 core_linux_clang:CONFIG += disable_enum_constexpr_conversion
 
-core_android {
-    INCLUDEPATH += $$PWD/build/android/include
-    CORE_BOOST_LIBS = $$PWD/build/android/lib/$$CORE_BUILDS_PLATFORM_PREFIX
-
-    DEFINES += "_HAS_AUTO_PTR_ETC=0"
-}
-
 disable_enum_constexpr_conversion {
     QMAKE_CFLAGS += -Wno-enum-constexpr-conversion
     QMAKE_CXXFLAGS += -Wno-enum-constexpr-conversion
-}
-
-bundle_xcframeworks {
-    xcframework_platform_ios_simulator {
-        CORE_BOOST_LIBS = $$PWD/build/ios_xcframework/ios_simulator/lib/$$CORE_BUILDS_PLATFORM_PREFIX
-    } else {
-        CORE_BOOST_LIBS = $$PWD/build/ios_xcframework/ios/lib/$$CORE_BUILDS_PLATFORM_PREFIX
-    }
 }
 
 core_win_arm64 {
     DEFINES += MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS=0
 }
 
-core_windows {
-    VS_VERSION=140
-    VS_DEBUG=
-    VS_ARCH=x64
-    core_debug:VS_DEBUG=gd-
-    core_win_32:VS_ARCH=x32
-    core_win_arm64:VS_ARCH=a64
-    vs2019:VS_VERSION=142
-
-    DEFINES += BOOST_USE_WINDOWS_H BOOST_WINAPI_NO_REDECLARATIONS
-
-    BOOST_POSTFIX = -vc$${VS_VERSION}-mt-$${VS_DEBUG}$${VS_ARCH}-1_72
-
-    core_boost_libs:LIBS += -L$$CORE_BOOST_LIBS -llibboost_system$$BOOST_POSTFIX -llibboost_filesystem$$BOOST_POSTFIX
-    core_boost_regex:LIBS += -L$$CORE_BOOST_LIBS -llibboost_regex$$BOOST_POSTFIX
-    core_boost_date_time:LIBS += -L$$CORE_BOOST_LIBS -llibboost_date_time$$BOOST_POSTFIX
+use_system_boost {
+    core_boost_libs:LIBS += -lboost_system -lboost_filesystem
+    core_boost_regex:LIBS += -lboost_regex
+    core_boost_date_time:LIBS += -lboost_date_time
 } else {
-    core_boost_libs:LIBS += -L$$CORE_BOOST_LIBS -lboost_system -lboost_filesystem
-    core_boost_regex:LIBS += -L$$CORE_BOOST_LIBS -lboost_regex
-    core_boost_date_time:LIBS += -L$$CORE_BOOST_LIBS -lboost_date_time
+    core_windows {
+        VS_VERSION=140
+        VS_DEBUG=
+        VS_ARCH=x64
+        core_debug:VS_DEBUG=gd-
+        core_win_32:VS_ARCH=x32
+        core_win_arm64:VS_ARCH=a64
+        vs2019:VS_VERSION=142
+
+        DEFINES += BOOST_USE_WINDOWS_H BOOST_WINAPI_NO_REDECLARATIONS
+
+        BOOST_POSTFIX = -vc$${VS_VERSION}-mt-$${VS_DEBUG}$${VS_ARCH}-1_72
+
+        core_boost_libs:LIBS += -L$$CORE_BOOST_LIBS -llibboost_system$$BOOST_POSTFIX -llibboost_filesystem$$BOOST_POSTFIX
+        core_boost_regex:LIBS += -L$$CORE_BOOST_LIBS -llibboost_regex$$BOOST_POSTFIX
+        core_boost_date_time:LIBS += -L$$CORE_BOOST_LIBS -llibboost_date_time$$BOOST_POSTFIX
+    } else {
+        core_boost_libs:LIBS += -L$$CORE_BOOST_LIBS -lboost_system -lboost_filesystem
+        core_boost_regex:LIBS += -L$$CORE_BOOST_LIBS -lboost_regex
+        core_boost_date_time:LIBS += -L$$CORE_BOOST_LIBS -lboost_date_time
+    }
 }

--- a/Common/3dParty/cryptopp/cryptopp.pri
+++ b/Common/3dParty/cryptopp/cryptopp.pri
@@ -1,0 +1,7 @@
+use_system_cryptopp {
+    LIBS += -lcryptopp
+} else {
+    DEFINES += CRYPTOPP_DISABLE_ASM
+    INCLUDEPATH += $$PWD/..
+    LIBS += -L$$CORE_BUILDS_LIBRARIES_PATH -lCryptoPPLib
+}

--- a/Common/3dParty/googletest/googletest.pri
+++ b/Common/3dParty/googletest/googletest.pri
@@ -1,12 +1,27 @@
-CORE_GTEST_PATH=$$PWD/googletest/googletest
+use_system_googletest {
+    LIBS += -lgtest
+    !core_no_gtest_main:LIBS += -lgtest_main
+    core_gmock:LIBS += -lgmock
+} else {
+    CORE_GTEST_PATH=$$PWD/googletest/googletest
 
-CONFIG += c++14
+    CONFIG += c++14
 
-CORE_GTEST_PATH_INCLUDE = $$CORE_GTEST_PATH/include
+    CORE_GTEST_PATH_INCLUDE = $$CORE_GTEST_PATH/include
 
-INCLUDEPATH += $$CORE_GTEST_PATH
-INCLUDEPATH += $$CORE_GTEST_PATH_INCLUDE
+    INCLUDEPATH += $$CORE_GTEST_PATH
+    INCLUDEPATH += $$CORE_GTEST_PATH_INCLUDE
 
-SOURCES += \
-    $$CORE_GTEST_PATH/src/gtest-all.cc \
-	$$CORE_GTEST_PATH/src/gtest_main.cc
+    SOURCES += \
+        $$CORE_GTEST_PATH/src/gtest-all.cc
+    !core_no_gtest_main:SOURCES += $$CORE_GTEST_PATH/src/gtest_main.cc
+
+    core_gmock {
+        CORE_GMOCK_PATH=$$PWD/googletest/googlemock
+
+        INCLUDEPATH += $$CORE_GMOCK_PATH
+        INCLUDEPATH += $$CORE_GMOCK_PATH/include
+
+        SOURCES += $$CORE_GMOCK_PATH/src/gmock-all.cc
+    }
+}

--- a/Common/3dParty/harfbuzz/.gitignore
+++ b/Common/3dParty/harfbuzz/.gitignore
@@ -1,3 +1,3 @@
 harfbuzz/
-harfbuzz.pri
+harfbuzz_sources.pri
 module.version

--- a/Common/3dParty/harfbuzz/harfbuzz.pri
+++ b/Common/3dParty/harfbuzz/harfbuzz.pri
@@ -1,0 +1,6 @@
+use_system_harfbuzz {
+    INCLUDEPATH += /usr/include/harfbuzz
+    LIBS += -lharfbuzz
+} else {
+    include($$PWD/harfbuzz_sources.pri)
+}

--- a/Common/3dParty/harfbuzz/make.py
+++ b/Common/3dParty/harfbuzz/make.py
@@ -121,10 +121,10 @@ if not base.is_dir("harfbuzz"):
   else:
     qmake_content_lines.append("")
 
-  if (base.is_file("./harfbuzz.pri")):
-    base.delete_file("./harfbuzz.pri")
+  if (base.is_file("./harfbuzz_sources.pri")):
+    base.delete_file("./harfbuzz_sources.pri")
 
-  with open("./harfbuzz.pri", "w") as file:
+  with open("./harfbuzz_sources.pri", "w") as file:
     file.write("\n".join(qmake_content_lines))
 
   #base.delete_file("./harfbuzz/src/hb-ft.cc")

--- a/Common/3dParty/heif/heif.pri
+++ b/Common/3dParty/heif/heif.pri
@@ -1,3 +1,7 @@
+use_system_heif {
+    LIBS += -lheif -lde265 -lx265
+} else {
+
 DEFINES += LIBHEIF_STATIC_BUILD
 
 HEIF_BUILDS_PLATFORM_PREFIX = $$CORE_BUILDS_PLATFORM_PREFIX
@@ -40,3 +44,5 @@ core_mac | core_ios {
 		-L$$PWD/libde265/build/$$HEIF_BUILDS_PLATFORM_PREFIX/$$CORE_BUILDS_CONFIGURATION_PREFIX/libde265 -lde265 \
 		-L$$HEIF_BUILD_PATH/libheif -lheif
 }
+
+} # !use_system_heif

--- a/Common/3dParty/icu/icu.pri
+++ b/Common/3dParty/icu/icu.pri
@@ -1,3 +1,7 @@
+use_system_icu {
+    LIBS += -licuuc -licudata
+} else {
+
 ICU_MAJOR_VER = 74
 
 core_windows {
@@ -62,3 +66,5 @@ core_android {
     LIBS        += $$PWD/android/build/$$CORE_BUILDS_PLATFORM_PREFIX_DST/libicuuc.a
     LIBS        += $$PWD/android/build/$$CORE_BUILDS_PLATFORM_PREFIX_DST/libicudata.a
 }
+
+} # !use_system_icu

--- a/Common/3dParty/openssl/common/common_openssl.cpp
+++ b/Common/3dParty/openssl/common/common_openssl.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "./common_openssl.h"
+#include <openssl/opensslv.h>
 #include <openssl/sha.h>
 #include <openssl/rsa.h>
 #include <openssl/bio.h>
@@ -138,18 +139,24 @@ namespace NSOpenSSL
 		publicKey = NULL;
 		privateKey = NULL;
 
-		RSA* rsa = RSA_new();
-		BIGNUM *exponent = BN_new();
-
-		BN_set_word(exponent, RSA_F4);
-		int result = RSA_generate_multi_prime_key(rsa, 2048, 2, exponent, NULL);
-		if (0 == result)
+		EVP_PKEY* pkey = NULL;
+		EVP_PKEY_CTX* pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL);
+		if (!pctx)
 			return false;
+
+		if (EVP_PKEY_keygen_init(pctx) <= 0 ||
+		    EVP_PKEY_CTX_set_rsa_keygen_bits(pctx, 2048) <= 0 ||
+		    EVP_PKEY_keygen(pctx, &pkey) <= 0)
+		{
+			EVP_PKEY_CTX_free(pctx);
+			return false;
+		}
+		EVP_PKEY_CTX_free(pctx);
 
 		if (true)
 		{
 			BIO* bio = BIO_new(BIO_s_mem());
-			if (PEM_write_bio_RSAPrivateKey(bio, rsa, NULL, NULL, 0, NULL, NULL))
+			if (PEM_write_bio_PrivateKey(bio, pkey, NULL, NULL, 0, NULL, NULL))
 			{
 				int key_length = BIO_pending(bio);
 				privateKey = openssl_alloc(key_length + 1);
@@ -168,7 +175,7 @@ namespace NSOpenSSL
 		if (true)
 		{
 			BIO* bio = BIO_new(BIO_s_mem());
-			if (PEM_write_bio_RSA_PUBKEY(bio, rsa))
+			if (PEM_write_bio_PUBKEY(bio, pkey))
 			{
 				int key_length = BIO_pending(bio);
 				publicKey = openssl_alloc(key_length + 1);
@@ -185,8 +192,7 @@ namespace NSOpenSSL
 			BIO_free_all(bio);
 		}
 
-		BN_free(exponent);
-		RSA_free(rsa);
+		EVP_PKEY_free(pkey);
 
 		return (NULL != publicKey && NULL != privateKey) ? true : false;
 	}
@@ -551,7 +557,6 @@ namespace NSOpenSSL
 	bool AES_Encrypt(int type, const unsigned char* key, const unsigned char* iv, const unsigned char* data, const unsigned int& size, unsigned char*& data_crypt, unsigned int& data_crypt_len)
 	{
 		EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
-		EVP_CIPHER_CTX_init(ctx);
 		EVP_EncryptInit_ex(ctx, _get_cipher_aes(type), NULL, key, iv);
 		EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, 16, NULL);
 		int out_len1 = (int)size + AES_BLOCK_SIZE;
@@ -561,13 +566,11 @@ namespace NSOpenSSL
 		EVP_EncryptFinal_ex(ctx, data_crypt + out_len1, &out_len2);
 		data_crypt_len = out_len1 + out_len2;
 		EVP_CIPHER_CTX_free(ctx);
-		EVP_cleanup();
 		return true;
 	}
 	bool AES_Decrypt(int type, const unsigned char* key, const unsigned char* iv, const unsigned char* data, const unsigned int& size, unsigned char*& data_decrypt, unsigned int& data_decrypt_len)
 	{
 		EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
-		EVP_CIPHER_CTX_init(ctx);
 		EVP_DecryptInit_ex(ctx, _get_cipher_aes(type), NULL, key, iv);
 		EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, 16, NULL);
 		int out_len1 = (int)size;
@@ -577,7 +580,6 @@ namespace NSOpenSSL
 		EVP_DecryptFinal_ex(ctx, data_decrypt + out_len1, &out_len2);
 		data_decrypt_len = out_len1 + out_len2;
 		EVP_CIPHER_CTX_free(ctx);
-		EVP_cleanup();
 		return true;
 	}
 

--- a/Common/3dParty/openssl/openssl.pri
+++ b/Common/3dParty/openssl/openssl.pri
@@ -28,12 +28,15 @@ core_ios {
 
 }
 
-core_windows {
-    LIBS += $$OPENSSL_LIBS_DIRECTORY/libssl.lib
-	LIBS += $$OPENSSL_LIBS_DIRECTORY/libcrypto.lib
+use_system_openssl {
+    LIBS += -lssl -lcrypto
 } else {
-    LIBS += $$OPENSSL_LIBS_DIRECTORY/libssl.a
-	LIBS += $$OPENSSL_LIBS_DIRECTORY/libcrypto.a
+    core_windows {
+        LIBS += $$OPENSSL_LIBS_DIRECTORY/libssl.lib
+        LIBS += $$OPENSSL_LIBS_DIRECTORY/libcrypto.lib
+    } else {
+        LIBS += $$OPENSSL_LIBS_DIRECTORY/libssl.a
+        LIBS += $$OPENSSL_LIBS_DIRECTORY/libcrypto.a
+    }
+    INCLUDEPATH += $$OPENSSL_LIBS_DIRECTORY/../include
 }
-
-INCLUDEPATH += $$OPENSSL_LIBS_DIRECTORY/../include

--- a/Common/3dParty/pole/pole.cpp
+++ b/Common/3dParty/pole/pole.cpp
@@ -1283,19 +1283,19 @@ void DirTree::debug()
     DirEntry* e = entry( i );
     if( !e ) continue;
     std::cout << i << ": ";
-	if( !e->valid ) std::cout << L"INVALID ";
+	if( !e->valid ) std::cout << "INVALID ";
     std::wcout << e->name << L" ";
-    if( e->dir ) std::cout << L"(Dir) ";
-    else std::cout << L"(File) ";
-    std::cout << e->size << L" ";
-	std::cout << L"s:" << e->start << L" ";
-    std::cout << L"(";
-    if( e->child == End ) std::cout << L"-"; else std::cout << e->child;
+    if( e->dir ) std::cout << "(Dir) ";
+    else std::cout << "(File) ";
+    std::cout << e->size << " ";
+	std::cout << "s:" << e->start << " ";
+    std::cout << "(";
+    if( e->child == End ) std::cout << "-"; else std::cout << e->child;
     std::cout << " ";
-    if( e->prev == End ) std::cout << L"-"; else std::cout << e->prev;
-    std::cout << L":";
-    if( e->next == End ) std::cout << L"-"; else std::cout << e->next;
-    std::cout << L")";    
+    if( e->prev == End ) std::cout << "-"; else std::cout << e->prev;
+    std::cout << ":";
+    if( e->next == End ) std::cout << "-"; else std::cout << e->next;
+    std::cout << ")";    
     std::cout << std::endl;
   }
 }

--- a/Common/3dParty/v8/v8.pri
+++ b/Common/3dParty/v8/v8.pri
@@ -1,3 +1,15 @@
+use_system_v8 {
+    CONFIG += c++2a
+    CONFIG += use_v8_monolith
+    DEFINES += V8_VERSION_89_PLUS
+    DEFINES += V8_VERSION_121_PLUS
+    DEFINES += V8_COMPRESS_POINTERS
+    DEFINES += DISABLE_MEMORY_LIMITATION
+
+    INCLUDEPATH += /usr/include/v8
+    LIBS += -lv8_monolith -lpthread
+} else {
+
 CORE_V8_PATH_OVERRIDE=$$PWD
 !v8_version_60:CONFIG += v8_version_89
 
@@ -86,3 +98,5 @@ core_mac {
 core_android {
     LIBS += -L$$CORE_V8_PATH_LIBS -lv8_monolith
 }
+
+} # !use_system_v8

--- a/Common/3dParty/v8/v8.pri
+++ b/Common/3dParty/v8/v8.pri
@@ -3,11 +3,13 @@ use_system_v8 {
     CONFIG += use_v8_monolith
     DEFINES += V8_VERSION_89_PLUS
     DEFINES += V8_VERSION_121_PLUS
-    DEFINES += V8_COMPRESS_POINTERS
     DEFINES += DISABLE_MEMORY_LIMITATION
+    # Node.js V8 does not enable pointer compression by default
+    # and snapshots require sdkjs compiled from source
+    # so neither V8_COMPRESS_POINTERS nor V8_SUPPORT_SNAPSHOTS are defined
 
     INCLUDEPATH += /usr/include/v8
-    LIBS += -lv8_monolith -lpthread
+    LIBS += -lv8 -lpthread
 } else {
 
 CORE_V8_PATH_OVERRIDE=$$PWD

--- a/Common/base.pri
+++ b/Common/base.pri
@@ -630,7 +630,6 @@ core_windows {
 	QMAKE_CXXFLAGS += -Wall -Wno-ignored-qualifiers
 }
 
-DEFINES += CRYPTOPP_DISABLE_ASM
 }
 
 core_ios|core_mac {

--- a/Common/cfcpp/test/test.pro
+++ b/Common/cfcpp/test/test.pro
@@ -1,15 +1,15 @@
-include(gtest_dependency.pri)
-
 TARGET = test
 TEMPLATE = app
 CONFIG += console c++11
 CONFIG -= app_bundle
 CONFIG += thread
 CONFIG -= qt
+CONFIG += core_no_gtest_main core_gmock
 
 CORE_ROOT_DIR = $$PWD/../../..
 PWD_ROOT_DIR = $$PWD
 include(../../base.pri)
+include($$CORE_ROOT_DIR/Common/3dParty/googletest/googletest.pri)
 
 ADD_DEPENDENCY(UnicodeConverter, kernel, CompoundFileLib)
 

--- a/DesktopEditor/cximage/jasper/jpc/jpc_qmfb.c
+++ b/DesktopEditor/cximage/jasper/jpc/jpc_qmfb.c
@@ -83,6 +83,7 @@
 #include "jasper/jas_malloc.h"
 #include "jasper/jas_math.h"
 
+#include "jpc_fix.h"
 #include "jpc_qmfb.h"
 #include "jpc_tsfb.h"
 #include "jpc_math.h"
@@ -96,7 +97,7 @@
 
 int jpc_ft_analyze(jpc_fix_t *a, int xstart, int ystart, int width, int height,
   int stride);
-int jpc_ft_synthesize(int *a, int xstart, int ystart, int width, int height,
+int jpc_ft_synthesize(jpc_fix_t *a, int xstart, int ystart, int width, int height,
   int stride);
 
 int jpc_ns_analyze(jpc_fix_t *a, int xstart, int ystart, int width, int height,
@@ -1592,7 +1593,7 @@ int jpc_ft_analyze(jpc_fix_t *a, int xstart, int ystart, int width, int height,
 
 }
 
-int jpc_ft_synthesize(int *a, int xstart, int ystart, int width, int height,
+int jpc_ft_synthesize(jpc_fix_t *a, int xstart, int ystart, int width, int height,
   int stride)
 {
 	int numrows = height;

--- a/DesktopEditor/cximage/jasper/jpc/jpc_qmfb.h
+++ b/DesktopEditor/cximage/jasper/jpc/jpc_qmfb.h
@@ -76,6 +76,8 @@
 
 #include "jasper/jas_seq.h"
 
+#include "jpc_fix.h"
+
 /******************************************************************************\
 * Constants.
 \******************************************************************************/
@@ -101,8 +103,8 @@ any particular platform.  Hopefully, it is not too unreasonable, however. */
 #endif
 
 typedef struct {
-	int (*analyze)(int *, int, int, int, int, int);
-	int (*synthesize)(int *, int, int, int, int, int);
+	int (*analyze)(jpc_fix_t *, int, int, int, int, int);
+	int (*synthesize)(jpc_fix_t *, int, int, int, int, int);
 	double *lpenergywts;
 	double *hpenergywts;
 } jpc_qmfb2d_t;

--- a/DesktopEditor/cximage/jasper/jpc/jpc_tsfb.c
+++ b/DesktopEditor/cximage/jasper/jpc/jpc_tsfb.c
@@ -119,7 +119,7 @@ void jpc_tsfb_destroy(jpc_tsfb_t *tsfb)
 	free(tsfb);
 }
 
-int jpc_tsfb_analyze2(jpc_tsfb_t *tsfb, int *a, int xstart, int ystart,
+int jpc_tsfb_analyze2(jpc_tsfb_t *tsfb, jpc_fix_t *a, int xstart, int ystart,
   int width, int height, int stride, int numlvls)
 {
 	if (width > 0 && height > 0) {
@@ -150,7 +150,7 @@ int jpc_tsfb_analyze(jpc_tsfb_t *tsfb, jas_seq2d_t *a)
 #endif
 }
 
-int jpc_tsfb_synthesize2(jpc_tsfb_t *tsfb, int *a, int xstart, int ystart,
+int jpc_tsfb_synthesize2(jpc_tsfb_t *tsfb, jpc_fix_t *a, int xstart, int ystart,
   int width, int height, int stride, int numlvls)
 {
 	if (numlvls > 0) {

--- a/DesktopEditor/doctrenderer/embed/HashEmbed.cpp
+++ b/DesktopEditor/doctrenderer/embed/HashEmbed.cpp
@@ -6,6 +6,8 @@ JSSmart<CJSValue> CHashEmbed::hash(JSSmart<CJSValue> data, JSSmart<CJSValue> siz
 	int _size = size->toInt32();
 	int _alg = alg->toInt32();
 	unsigned char* pData = m_pHash->hash(reinterpret_cast<const unsigned char*>(_data.c_str()), _size, _alg);
+	if (!pData)
+		return CJSContext::createNull();
 	return CJSContext::createUint8Array(pData, CHash::getDigestLength(static_cast<CHash::HashAlgs>(_alg)), false);
 }
 
@@ -16,5 +18,7 @@ JSSmart<CJSValue> CHashEmbed::hash2(JSSmart<CJSValue> password, JSSmart<CJSValue
 	int _spinCount = spinCount->toInt32();
 	int _alg = alg->toInt32();
 	unsigned char* pData = m_pHash->hash2(reinterpret_cast<const char*>(_password.c_str()), reinterpret_cast<const char*>(_salt.c_str()), _spinCount, _alg);
+	if (!pData)
+		return CJSContext::createNull();
 	return CJSContext::createUint8Array(pData, CHash::getDigestLength(static_cast<CHash::HashAlgs>(_alg)), false);
 }

--- a/DesktopEditor/doctrenderer/hash.cpp
+++ b/DesktopEditor/doctrenderer/hash.cpp
@@ -4,16 +4,58 @@
 #include "../common/Base64.h"
 #endif
 
-#include "openssl/sha.h"
-#include "openssl/md2.h"
-#include "openssl/md4.h"
-#include "openssl/md5.h"
-#include "openssl/whrlpool.h"
-#include "openssl/ripemd.h"
+#include <openssl/evp.h>
+#include <openssl/opensslv.h>
+
+#if OPENSSL_VERSION_MAJOR < 3
+#include <openssl/sha.h>
+#include <openssl/md4.h>
+#include <openssl/md5.h>
+#include <openssl/whrlpool.h>
+#include <openssl/ripemd.h>
+#ifndef OPENSSL_NO_MD2
+#include <openssl/md2.h>
+#endif
+#endif
 
 #include <cstring>
 #include <memory>
 #include <stdlib.h>
+
+/*
+ * OpenSSL 3.x deprecates the low-level one-shot hash functions (MD4(), MD5(),
+ * SHA1(), RIPEMD160(), WHIRLPOOL()) and removes MD2 entirely. Use EVP_Digest()
+ * as the single entry point for all algorithms. On OpenSSL 1.x the legacy
+ * one-shot functions are still available and used directly.
+ */
+#if OPENSSL_VERSION_MAJOR >= 3
+static const EVP_MD* hash_alg_to_evp_md(int alg)
+{
+	switch (alg)
+	{
+	case CHash::haMD4:       return EVP_md4();
+	case CHash::haMD5:       return EVP_md5();
+	case CHash::haRMD160:    return EVP_ripemd160();
+	case CHash::haSHA1:      return EVP_sha1();
+	case CHash::haSHA256:    return EVP_sha256();
+	case CHash::haSHA384:    return EVP_sha384();
+	case CHash::haSHA512:    return EVP_sha512();
+	/* MD2 and WHIRLPOOL are not available in the default OpenSSL 3.x provider.
+	 * haMD2 falls through to default and returns NULL. */
+	default:                 return NULL;
+	}
+}
+
+static bool evp_digest(const unsigned char* data, size_t len,
+                       unsigned char* out, int alg)
+{
+	const EVP_MD* md = hash_alg_to_evp_md(alg);
+	if (!md)
+		return false;
+	unsigned int md_len = 0;
+	return EVP_Digest(data, len, out, &md_len, md, NULL) == 1;
+}
+#endif
 
 int CHash::getDigestLength(HashAlgs alg)
 {
@@ -35,74 +77,35 @@ unsigned char* CHash::hash(const unsigned char* data, int size, int alg)
 	unsigned char* pBufData = NULL;
 	size_t d = (size_t)size;
 
+	nBufLen = getDigestLength((HashAlgs)alg);
+	if (0 == nBufLen)
+		return NULL;
+
+	pBufData = (unsigned char*)m_fAllocator(nBufLen);
+
+#if OPENSSL_VERSION_MAJOR >= 3
+	if (!evp_digest(data, d, pBufData, alg))
+	{
+		/* Algorithm not available (e.g. MD2 on OpenSSL 3.x). */
+		return NULL;
+	}
+#else
 	switch (alg)
 	{
-	case haMD2:
-	{
-		nBufLen = 16;
-		pBufData = (unsigned char*)m_fAllocator(nBufLen);
-		MD2(data, d, pBufData);
-		break;
+#ifndef OPENSSL_NO_MD2
+	case haMD2:       MD2(data, d, pBufData);       break;
+#endif
+	case haMD4:       MD4(data, d, pBufData);       break;
+	case haMD5:       MD5(data, d, pBufData);       break;
+	case haRMD160:    RIPEMD160(data, d, pBufData);  break;
+	case haSHA1:      SHA1(data, d, pBufData);       break;
+	case haSHA256:    SHA256(data, d, pBufData);     break;
+	case haSHA384:    SHA384(data, d, pBufData);     break;
+	case haSHA512:    SHA512(data, d, pBufData);     break;
+	case haWHIRLPOOL: WHIRLPOOL(data, d, pBufData); break;
+	default:          return NULL;
 	}
-	case haMD4:
-	{
-		nBufLen = 16;
-		pBufData = (unsigned char*)m_fAllocator(nBufLen);
-		MD4(data, d, pBufData);
-		break;
-	}
-	case haMD5:
-	{
-		nBufLen = 16;
-		pBufData = (unsigned char*)m_fAllocator(nBufLen);
-		MD5(data, d, pBufData);
-		break;
-	}
-	case haRMD160:
-	{
-		nBufLen = 20;
-		pBufData = (unsigned char*)m_fAllocator(nBufLen);
-		RIPEMD160(data, d, pBufData);
-		break;
-	}
-	case haSHA1:
-	{
-		nBufLen = 20;
-		pBufData = (unsigned char*)m_fAllocator(nBufLen);
-		SHA1(data, d, pBufData);
-		break;
-	}
-	case haSHA256:
-	{
-		nBufLen = 32;
-		pBufData = (unsigned char*)m_fAllocator(nBufLen);
-		SHA256(data, d, pBufData);
-		break;
-	}
-	case haSHA384:
-	{
-		nBufLen = 48;
-		pBufData = (unsigned char*)m_fAllocator(nBufLen);
-		SHA384(data, d, pBufData);
-		break;
-	}
-	case haSHA512:
-	{
-		nBufLen = 64;
-		pBufData = (unsigned char*)m_fAllocator(nBufLen);
-		SHA512(data, d, pBufData);
-		break;
-	}
-	case haWHIRLPOOL:
-	{
-		nBufLen = 64;
-		pBufData = (unsigned char*)m_fAllocator(nBufLen);
-		WHIRLPOOL(data, d, pBufData);
-		break;
-	}
-	default:
-		break;
-	}
+#endif
 
 	return pBufData;
 }
@@ -244,56 +247,25 @@ void hash_iteration(unsigned char*& input, int iter, unsigned char*& tmp, int al
 	input[alg_size + 2] = 0xFF & (iter >> 16);
 	input[alg_size + 3] = 0xFF & (iter >> 24);
 
+#if OPENSSL_VERSION_MAJOR >= 3
+	evp_digest(input, alg_size + 4, tmp, alg);
+#else
 	switch (alg)
 	{
-	case CHash::haMD2:
-	{
-		MD2(input, alg_size + 4, tmp);
-		break;
+#ifndef OPENSSL_NO_MD2
+	case CHash::haMD2:       MD2(input, alg_size + 4, tmp);       break;
+#endif
+	case CHash::haMD4:       MD4(input, alg_size + 4, tmp);       break;
+	case CHash::haMD5:       MD5(input, alg_size + 4, tmp);       break;
+	case CHash::haRMD160:    RIPEMD160(input, alg_size + 4, tmp);  break;
+	case CHash::haSHA1:      SHA1(input, alg_size + 4, tmp);       break;
+	case CHash::haSHA256:    SHA256(input, alg_size + 4, tmp);     break;
+	case CHash::haSHA384:    SHA384(input, alg_size + 4, tmp);     break;
+	case CHash::haSHA512:    SHA512(input, alg_size + 4, tmp);     break;
+	case CHash::haWHIRLPOOL: WHIRLPOOL(input, alg_size + 4, tmp); break;
+	default: break;
 	}
-	case CHash::haMD4:
-	{
-		MD4(input, alg_size + 4, tmp);
-		break;
-	}
-	case CHash::haMD5:
-	{
-		MD5(input, alg_size + 4, tmp);
-		break;
-	}
-	case CHash::haRMD160:
-	{
-		RIPEMD160(input, alg_size + 4, tmp);
-		break;
-	}
-	case CHash::haSHA1:
-	{
-		SHA1(input, alg_size + 4, tmp);
-		break;
-	}
-	case CHash::haSHA256:
-	{
-		SHA256(input, alg_size + 4, tmp);
-		break;
-	}
-	case CHash::haSHA384:
-	{
-		SHA384(input, alg_size + 4, tmp);
-		break;
-	}
-	case CHash::haSHA512:
-	{
-		SHA512(input, alg_size + 4, tmp);
-		break;
-	}
-	case CHash::haWHIRLPOOL:
-	{
-		WHIRLPOOL(input, alg_size + 4, tmp);
-		break;
-	}
-	default:
-		break;
-	}
+#endif
 
 	unsigned char* mem = input;
 	input = tmp;
@@ -315,76 +287,40 @@ unsigned char* CHash::hash2(const char* password, const char* salt, int spinCoun
 
 	free(passwordUtf16);
 
-	size_t alg_size = 0;
-	unsigned char* pBuffer1 = NULL;
+	size_t alg_size = getDigestLength((HashAlgs)alg);
+	if (0 == alg_size)
+	{
+		free(inputData);
+		return NULL;
+	}
+
+	unsigned char* pBuffer1 = (unsigned char*)m_fAllocator(alg_size + 4);
+
+#if OPENSSL_VERSION_MAJOR >= 3
+	if (!evp_digest(inputData, inputDataLen, pBuffer1, alg))
+	{
+		free(inputData);
+		return NULL;
+	}
+#else
 	switch (alg)
 	{
-	case haMD2:
-	{
-		alg_size = 16;
-		pBuffer1 = (unsigned char*)m_fAllocator(alg_size + 4);
-		MD2(inputData, inputDataLen, pBuffer1);
-		break;
-	}
-	case haMD4:
-	{
-		alg_size = 16;
-		pBuffer1 = (unsigned char*)m_fAllocator(alg_size + 4);
-		MD4(inputData, inputDataLen, pBuffer1);
-		break;
-	}
-	case haMD5:
-	{
-		alg_size = 16;
-		pBuffer1 = (unsigned char*)m_fAllocator(alg_size + 4);
-		MD5(inputData, inputDataLen, pBuffer1);
-		break;
-	}
-	case haRMD160:
-	{
-		alg_size = 20;
-		pBuffer1 = (unsigned char*)m_fAllocator(alg_size + 4);
-		RIPEMD160(inputData, inputDataLen, pBuffer1);
-		break;
-	}
-	case haSHA1:
-	{
-		alg_size = 20;
-		pBuffer1 = (unsigned char*)m_fAllocator(alg_size + 4);
-		SHA1(inputData, inputDataLen, pBuffer1);
-		break;
-	}
-	case haSHA256:
-	{
-		alg_size = 32;
-		pBuffer1 = (unsigned char*)m_fAllocator(alg_size + 4);
-		SHA256(inputData, inputDataLen, pBuffer1);
-		break;
-	}
-	case haSHA384:
-	{
-		alg_size = 48;
-		pBuffer1 = (unsigned char*)m_fAllocator(alg_size + 4);
-		SHA384(inputData, inputDataLen, pBuffer1);
-		break;
-	}
-	case haSHA512:
-	{
-		alg_size = 64;
-		pBuffer1 = (unsigned char*)m_fAllocator(alg_size + 4);
-		SHA512(inputData, inputDataLen, pBuffer1);
-		break;
-	}
-	case haWHIRLPOOL:
-	{
-		alg_size = 64;
-		pBuffer1 = (unsigned char*)m_fAllocator(alg_size + 4);
-		WHIRLPOOL(inputData, inputDataLen, pBuffer1);
-		break;
-	}
+#ifndef OPENSSL_NO_MD2
+	case haMD2:       MD2(inputData, inputDataLen, pBuffer1);       break;
+#endif
+	case haMD4:       MD4(inputData, inputDataLen, pBuffer1);       break;
+	case haMD5:       MD5(inputData, inputDataLen, pBuffer1);       break;
+	case haRMD160:    RIPEMD160(inputData, inputDataLen, pBuffer1);  break;
+	case haSHA1:      SHA1(inputData, inputDataLen, pBuffer1);       break;
+	case haSHA256:    SHA256(inputData, inputDataLen, pBuffer1);     break;
+	case haSHA384:    SHA384(inputData, inputDataLen, pBuffer1);     break;
+	case haSHA512:    SHA512(inputData, inputDataLen, pBuffer1);     break;
+	case haWHIRLPOOL: WHIRLPOOL(inputData, inputDataLen, pBuffer1); break;
 	default:
-		break;
+		free(inputData);
+		return NULL;
 	}
+#endif
 
 	free(inputData);
 

--- a/DesktopEditor/doctrenderer/js_internal/v8/inspector/utils.cpp
+++ b/DesktopEditor/doctrenderer/js_internal/v8/inspector/utils.cpp
@@ -26,7 +26,11 @@ namespace NSJSBase
 
 	v8::Local<v8::Object> parseJson(const v8::Local<v8::Context>& context, const std::string& sJson)
 	{
+#ifdef V8_VERSION_121_PLUS
+		v8::MaybeLocal<v8::Value> jsonValue = v8::JSON::Parse(context, CreateV8String(v8::Isolate::GetCurrent(), sJson));
+#else
 		v8::MaybeLocal<v8::Value> jsonValue = v8::JSON::Parse(context, CreateV8String(context->GetIsolate(), sJson));
+#endif
 		if (jsonValue.IsEmpty())
 		{
 			return v8::Local<v8::Object>();

--- a/DesktopEditor/doctrenderer/js_internal/v8/inspector/v8_inspector_client.cpp
+++ b/DesktopEditor/doctrenderer/js_internal/v8/inspector/v8_inspector_client.cpp
@@ -22,7 +22,13 @@ namespace NSJSBase
 		// initialize all V8 inspector stuff
 		m_pChannel.reset(new CV8InspectorChannelImpl(m_pIsolate, fOnResponse));
 		m_pInspector = v8_inspector::V8Inspector::create(m_pIsolate, this);
+#ifdef V8_VERSION_121_PLUS
+		m_pSession = m_pInspector->connect(m_nContextGroupId, m_pChannel.get(), v8_inspector::StringView(),
+		    v8_inspector::V8Inspector::kFullyTrusted,
+		    v8_inspector::V8Inspector::kNotWaitingForDebugger);
+#else
 		m_pSession = m_pInspector->connect(m_nContextGroupId, m_pChannel.get(), v8_inspector::StringView());
+#endif
 		context->SetAlignedPointerInEmbedderData(1, this);
 
 		v8_inspector::StringView oContextName = convertToStringView("inspector" + std::to_string(nContextGroupId));

--- a/DesktopEditor/doctrenderer/js_internal/v8/v8_base.cpp
+++ b/DesktopEditor/doctrenderer/js_internal/v8/v8_base.cpp
@@ -259,10 +259,12 @@ namespace NSJSBase
 		m_internal->m_contextPersistent.Reset();
 		// destroy native object in the weak handles before isolate disposal
 		v8::Isolate* isolate = m_internal->m_isolate;
+#ifndef V8_VERSION_121_PLUS
 		{
 			v8::Isolate::Scope scope(isolate);
 			isolate->VisitHandlesWithClassIds(WeakHandleVisitor::getInstance());
 		}
+#endif
 		isolate->Dispose();
 		m_internal->m_isolate = NULL;
 	}

--- a/DesktopEditor/doctrenderer/js_internal/v8/v8_base.cpp
+++ b/DesktopEditor/doctrenderer/js_internal/v8/v8_base.cpp
@@ -618,7 +618,7 @@ namespace NSJSBase
 	// this function is called when method from embedded object is called
 	void _Call(const v8::FunctionCallbackInfo<v8::Value>& args)
 	{
-		CJSEmbedObject* _this = (CJSEmbedObject*)unwrap_native(args.Holder());
+		CJSEmbedObject* _this = (CJSEmbedObject*)unwrap_native(args.V8Holder());
 		CJSFunctionArgumentsV8 _args(&args, 0);
 		JSSmart<CJSValue> funcIndex = js_value(args.Data());
 		CJSEmbedObjectAdapterV8* _adapter = static_cast<CJSEmbedObjectAdapterV8*>(_this->getAdapter());

--- a/DesktopEditor/doctrenderer/js_internal/v8/v8_base.h
+++ b/DesktopEditor/doctrenderer/js_internal/v8/v8_base.h
@@ -35,6 +35,11 @@
 #define V8IsolateFirstArg CV8Worker::GetCurrent(),
 #define V8IsolateOneArg CV8Worker::GetCurrent()
 #define V8ToChecked ToChecked
+#ifdef V8_VERSION_121_PLUS
+#define V8Holder This
+#else
+#define V8Holder Holder
+#endif
 #else
 #define kV8NormalString v8::NewStringType::kNormal
 #define kV8ProduceCodeCache v8::ScriptCompiler::kProduceCodeCache
@@ -1009,7 +1014,7 @@ inline void js_return(const v8::PropertyCallbackInfo<v8::Value>& info, JSSmart<N
 #define PROPERTY_GET(NAME, NAME_EMBED)                                                      \
 	void NAME(v8::Local<v8::String> _name, const v8::PropertyCallbackInfo<v8::Value>& info) \
 {                                                                                           \
-	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(info.Holder()));    \
+	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(info.V8Holder()));    \
 	if (!_this) return;                                                                     \
 	JSSmart<CJSValue> ret = _this->NAME_EMBED();                                            \
 	js_return(info, ret);                                                                   \
@@ -1018,7 +1023,7 @@ inline void js_return(const v8::PropertyCallbackInfo<v8::Value>& info, JSSmart<N
 #define FUNCTION_WRAPPER_V8_0(NAME, NAME_EMBED)                                             \
 	void NAME(const v8::FunctionCallbackInfo<v8::Value>& args)                              \
 {                                                                                           \
-	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.Holder()));    \
+	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.V8Holder()));    \
 	if (!_this) return;                                                                     \
 	JSSmart<CJSValue> ret = _this->NAME_EMBED();                                            \
 	js_return(args, ret);                                                                   \
@@ -1029,7 +1034,7 @@ inline void js_return(const v8::PropertyCallbackInfo<v8::Value>& info, JSSmart<N
 #define FUNCTION_WRAPPER_V8_1(NAME, NAME_EMBED)                                             \
 	void NAME(const v8::FunctionCallbackInfo<v8::Value>& args)                              \
 {                                                                                           \
-	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.Holder()));    \
+	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.V8Holder()));    \
 	if (!_this) return;                                                                     \
 	JSSmart<CJSValue> ret = _this->NAME_EMBED(js_value(args[0]));                           \
 	js_return(args, ret);                                                                   \
@@ -1037,7 +1042,7 @@ inline void js_return(const v8::PropertyCallbackInfo<v8::Value>& info, JSSmart<N
 #define FUNCTION_WRAPPER_V8_2(NAME, NAME_EMBED)                                             \
 	void NAME(const v8::FunctionCallbackInfo<v8::Value>& args)                              \
 {                                                                                           \
-	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.Holder()));    \
+	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.V8Holder()));    \
 	if (!_this) return;                                                                     \
 	JSSmart<CJSValue> ret = _this->NAME_EMBED(js_value(args[0]), js_value(args[1]));        \
 	js_return(args, ret);                                                                   \
@@ -1045,7 +1050,7 @@ inline void js_return(const v8::PropertyCallbackInfo<v8::Value>& info, JSSmart<N
 #define FUNCTION_WRAPPER_V8_3(NAME, NAME_EMBED)                                                             \
 	void NAME(const v8::FunctionCallbackInfo<v8::Value>& args)                                              \
 {                                                                                                           \
-	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.Holder()));                    \
+	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.V8Holder()));                    \
 	if (!_this) return;                                                                                     \
 	JSSmart<CJSValue> ret = _this->NAME_EMBED(js_value(args[0]), js_value(args[1]), js_value(args[2]));     \
 	js_return(args, ret);                                                                                   \
@@ -1053,7 +1058,7 @@ inline void js_return(const v8::PropertyCallbackInfo<v8::Value>& info, JSSmart<N
 #define FUNCTION_WRAPPER_V8_4(NAME, NAME_EMBED)                                                                             \
 	void NAME(const v8::FunctionCallbackInfo<v8::Value>& args)                                                              \
 {                                                                                                                           \
-	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.Holder()));                                    \
+	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.V8Holder()));                                    \
 	if (!_this) return;                                                                                                     \
 	JSSmart<CJSValue> ret = _this->NAME_EMBED(js_value(args[0]), js_value(args[1]), js_value(args[2]), js_value(args[3]));  \
 	js_return(args, ret);                                                                                                   \
@@ -1061,7 +1066,7 @@ inline void js_return(const v8::PropertyCallbackInfo<v8::Value>& info, JSSmart<N
 #define FUNCTION_WRAPPER_V8_5(NAME, NAME_EMBED)                                                                                                 \
 	void NAME(const v8::FunctionCallbackInfo<v8::Value>& args)                                                                                  \
 {                                                                                                                                               \
-	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.Holder()));                                                        \
+	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.V8Holder()));                                                        \
 	if (!_this) return;                                                                                                                         \
 	JSSmart<CJSValue> ret = _this->NAME_EMBED(js_value(args[0]), js_value(args[1]), js_value(args[2]), js_value(args[3]), js_value(args[4]));   \
 	js_return(args, ret);                                                                                                                       \
@@ -1069,7 +1074,7 @@ inline void js_return(const v8::PropertyCallbackInfo<v8::Value>& info, JSSmart<N
 #define FUNCTION_WRAPPER_V8_6(NAME, NAME_EMBED)                                                                                                                    \
 	void NAME(const v8::FunctionCallbackInfo<v8::Value>& args)                                                                                                     \
 {                                                                                                                                                                  \
-	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.Holder()));                                                                           \
+	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.V8Holder()));                                                                           \
 	if (!_this) return;                                                                                                                                            \
 	JSSmart<CJSValue> ret = _this->NAME_EMBED(js_value(args[0]), js_value(args[1]), js_value(args[2]), js_value(args[3]), js_value(args[4]), js_value(args[5]));   \
 	js_return(args, ret);                                                                                                                                          \
@@ -1077,7 +1082,7 @@ inline void js_return(const v8::PropertyCallbackInfo<v8::Value>& info, JSSmart<N
 #define FUNCTION_WRAPPER_V8_7(NAME, NAME_EMBED)                                                                                                 \
 	void NAME(const v8::FunctionCallbackInfo<v8::Value>& args)                                                                                  \
 {                                                                                                                                               \
-	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.Holder()));                                                        \
+	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.V8Holder()));                                                        \
 	if (!_this) return;                                                                                                                         \
 	JSSmart<CJSValue> ret = _this->NAME_EMBED(js_value(args[0]), js_value(args[1]), js_value(args[2]), js_value(args[3]), js_value(args[4]),    \
 	js_value(args[5]), js_value(args[6]));                                                                                                      \
@@ -1086,7 +1091,7 @@ inline void js_return(const v8::PropertyCallbackInfo<v8::Value>& info, JSSmart<N
 #define FUNCTION_WRAPPER_V8_8(NAME, NAME_EMBED)                                                                                                 \
 	void NAME(const v8::FunctionCallbackInfo<v8::Value>& args)                                                                                  \
 {                                                                                                                                               \
-	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.Holder()));                                                        \
+	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.V8Holder()));                                                        \
 	if (!_this) return;                                                                                                                         \
 	JSSmart<CJSValue> ret = _this->NAME_EMBED(js_value(args[0]), js_value(args[1]), js_value(args[2]), js_value(args[3]), js_value(args[4]),    \
 	js_value(args[5]), js_value(args[6]), js_value(args[7]));                                                                                   \
@@ -1095,7 +1100,7 @@ inline void js_return(const v8::PropertyCallbackInfo<v8::Value>& info, JSSmart<N
 #define FUNCTION_WRAPPER_V8_9(NAME, NAME_EMBED)                                                                                                 \
 	void NAME(const v8::FunctionCallbackInfo<v8::Value>& args)                                                                                  \
 {                                                                                                                                               \
-	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.Holder()));                                                        \
+	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.V8Holder()));                                                        \
 	if (!_this) return;                                                                                                                         \
 	JSSmart<CJSValue> ret = _this->NAME_EMBED(js_value(args[0]), js_value(args[1]), js_value(args[2]), js_value(args[3]), js_value(args[4]),    \
 	js_value(args[5]), js_value(args[6]), js_value(args[7]), js_value(args[8]));                                                                \
@@ -1104,7 +1109,7 @@ inline void js_return(const v8::PropertyCallbackInfo<v8::Value>& info, JSSmart<N
 #define FUNCTION_WRAPPER_V8_10(NAME, NAME_EMBED)                                                                                                                \
 	void NAME(const v8::FunctionCallbackInfo<v8::Value>& args)                                                                                                  \
 {                                                                                                                                                               \
-	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.Holder()));                                                                        \
+	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.V8Holder()));                                                                        \
 	if (!_this) return;                                                                                                                                         \
 	JSSmart<CJSValue> ret = _this->NAME_EMBED(js_value(args[0]), js_value(args[1]), js_value(args[2]), js_value(args[3]), js_value(args[4]), js_value(args[5]), \
 	js_value(args[6]), js_value(args[7]), js_value(args[8]), js_value(args[9]));                                                                                \
@@ -1113,7 +1118,7 @@ inline void js_return(const v8::PropertyCallbackInfo<v8::Value>& info, JSSmart<N
 #define FUNCTION_WRAPPER_V8_13(NAME, NAME_EMBED)                                                                                                                \
 	void NAME(const v8::FunctionCallbackInfo<v8::Value>& args)                                                                                                  \
 {                                                                                                                                                               \
-	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.Holder()));                                                                        \
+	CURRENTWRAPPER* _this = dynamic_cast<CURRENTWRAPPER*>(unwrap_native(args.V8Holder()));                                                                        \
 	if (!_this) return;                                                                                                                                         \
 	JSSmart<CJSValue> ret = _this->NAME_EMBED(js_value(args[0]), js_value(args[1]), js_value(args[2]), js_value(args[3]), js_value(args[4]), js_value(args[5]), \
 	js_value(args[6]), js_value(args[7]), js_value(args[8]), js_value(args[9]), js_value(args[10]), js_value(args[11]),                                         \

--- a/DesktopEditor/graphics/pro/js/qt/nativegraphics.pro
+++ b/DesktopEditor/graphics/pro/js/qt/nativegraphics.pro
@@ -668,8 +668,7 @@ HEADERS +=\
 	$$PDF_ROOT_DIR/SrcReader/PdfFont.h \
 	$$PDF_ROOT_DIR/SrcReader/PdfAnnot.h
 
-DEFINES += CRYPTOPP_DISABLE_ASM
-LIBS += -L$$CORE_BUILDS_LIBRARIES_PATH -lCryptoPPLib
+include($$CORE_ROOT_DIR/Common/3dParty/cryptopp/cryptopp.pri)
 
 # PdfWriter
 HEADERS += \

--- a/DesktopEditor/raster/heif/heif.h
+++ b/DesktopEditor/raster/heif/heif.h
@@ -1,5 +1,5 @@
 #include "../BgraFrame.h"
-#include "../../Common/3dParty/heif/libheif/libheif/api/libheif/heif.h"
+#include <libheif/heif.h>
 #include "../../UnicodeConverter/UnicodeConverter.h"
 
 namespace NSHeif {

--- a/DesktopEditor/xmlsec/src/osign/lib/src/certificate.cpp
+++ b/DesktopEditor/xmlsec/src/osign/lib/src/certificate.cpp
@@ -2,6 +2,7 @@
 #include "./utils.h"
 
 #include "../../../../../../Common/3dParty/openssl/common/common_openssl.h"
+#include <openssl/opensslv.h>
 #include <openssl/rand.h>
 #include <openssl/bio.h>
 #include <openssl/err.h>
@@ -12,9 +13,11 @@
 #include <openssl/sha.h>
 #include <openssl/ssl.h>
 #include <openssl/crypto.h>
-#include <openssl/engine.h>
 #include <openssl/evp.h>
 #include <openssl/conf.h>
+#if OPENSSL_VERSION_MAJOR < 3
+#include <openssl/engine.h>
+#endif
 #include <ctime>
 
 #include <iostream>
@@ -39,12 +42,13 @@ namespace OSign
 	tm ASN1_GetTimeT(ASN1_TIME* time)
 	{
 		struct tm t;
-		const char* str = (const char*) time->data;
+		const char* str = (const char*)ASN1_STRING_get0_data(time);
 		size_t i = 0;
+		int tag = ASN1_STRING_type(time);
 
 		memset(&t, 0, sizeof(t));
 
-		if (time->type == V_ASN1_UTCTIME)
+		if (tag == V_ASN1_UTCTIME)
 		{
 			/* two digit year */
 			t.tm_year = (str[i++] - '0') * 10;
@@ -52,7 +56,7 @@ namespace OSign
 			if (t.tm_year < 70)
 				t.tm_year += 100;
 		}
-		else if (time->type == V_ASN1_GENERALIZEDTIME)
+		else if (tag == V_ASN1_GENERALIZEDTIME)
 		{
 			/* four digit year */
 			t.tm_year = (str[i++] - '0') * 1000;
@@ -104,8 +108,10 @@ namespace OSign
 			if (!g_is_initialize)
 			{
 				g_is_initialize = true;
+#if OPENSSL_VERSION_MAJOR < 3
 				ERR_load_crypto_strings();
 				OpenSSL_add_all_algorithms();
+#endif
 			}
 		}
 
@@ -285,7 +291,7 @@ namespace OSign
 				X509_EXTENSION* ext = X509_get_ext(m_internal->m_cert, subjectAltNameLoc);
 				ASN1_OCTET_STRING* oData = X509_EXTENSION_get_data(ext);
 
-				std::string sDataString = std::string((char*)oData->data, oData->length);
+				std::string sDataString = std::string((const char*)ASN1_STRING_get0_data(oData), ASN1_STRING_length(oData));
 				std::string::size_type posStart = 0;
 				std::string::size_type posEnd = sDataString.find(';');
 

--- a/DesktopEditor/xmlsec/src/src/Certificate_openssl.h
+++ b/DesktopEditor/xmlsec/src/src/Certificate_openssl.h
@@ -11,6 +11,7 @@
 #include <unistd.h>
 #endif
 
+#include <openssl/opensslv.h>
 #include <openssl/bio.h>
 #include <openssl/err.h>
 #include <openssl/pem.h>
@@ -21,10 +22,15 @@
 #include <openssl/sha.h>
 #include <openssl/ssl.h>
 #include <openssl/crypto.h>
-#include <openssl/engine.h>
 #include <openssl/evp.h>
 #include <openssl/conf.h>
 #include <openssl/rand.h>
+#if OPENSSL_VERSION_MAJOR >= 3
+#include <openssl/param_build.h>
+#include <openssl/core_names.h>
+#else
+#include <openssl/engine.h>
+#endif
 
 #include <map>
 #include <memory>
@@ -126,9 +132,11 @@ public:
 		if (!g_is_initialize)
 		{
 			g_is_initialize = true;
+#if OPENSSL_VERSION_MAJOR < 3
 			ERR_load_crypto_strings();
 			OpenSSL_add_all_algorithms();
 			OPENSSL_config(NULL);
+#endif
 		}
 
 		m_cert = NULL;
@@ -146,9 +154,11 @@ public:
 		if (g_is_initialize)
 		{
 			g_is_initialize = false;
+#if OPENSSL_VERSION_MAJOR < 3
 			EVP_cleanup();
 			CRYPTO_cleanup_all_ex_data();
 			ERR_free_strings();
+#endif
 		}
 	}
 
@@ -188,6 +198,17 @@ public:
 				m_alg = OOXML_HASH_ALG_ECDSA_512;
 			}
 
+#if OPENSSL_VERSION_MAJOR >= 3
+			pctx = EVP_PKEY_CTX_new_from_name(NULL, "EC", NULL);
+			if (!pctx)
+				return false;
+			EVP_PKEY_keygen_init(pctx);
+			OSSL_PARAM params[2];
+			const char* group_name = OBJ_nid2sn(crypto_nid);
+			params[0] = OSSL_PARAM_construct_utf8_string("group", (char*)group_name, 0);
+			params[1] = OSSL_PARAM_construct_end();
+			EVP_PKEY_CTX_set_params(pctx, params);
+#else
 			EC_GROUP* group = EC_GROUP_new_by_curve_name(crypto_nid);
 
 			EC_GROUP_set_asn1_flag(group, OPENSSL_EC_NAMED_CURVE);
@@ -204,6 +225,7 @@ public:
 
 			EVP_PKEY_free(tmp);
 			EC_GROUP_free(group);
+#endif
 		}
 		else if (0 == key_alg.find("rsa"))
 		{
@@ -380,10 +402,10 @@ public:
 			return "";
 		}
 
-		if (asn1_serial->type == V_ASN1_NEG_INTEGER)
+		if (BN_is_negative(bn))
 		{
 			std::string sPositive = "1";
-			for (int i = 0; i < asn1_serial->length; ++i)
+			for (int i = 0; i < ASN1_STRING_length(asn1_serial); ++i)
 				sPositive += "00";
 			BIGNUM* pn = NULL;
 			int res = BN_hex2bn(&pn, sPositive.c_str());
@@ -564,18 +586,18 @@ public:
 			return true;
 		}
 
-		EVP_MD_CTX* pCtx = EVP_MD_CTX_create();
+		EVP_MD_CTX* pCtx = EVP_MD_CTX_new();
 		const EVP_MD* pDigest = Get_EVP_MD(nHashAlg);
 
-		int nError = EVP_SignInit(pCtx, pDigest);
-		nError = EVP_SignUpdate(pCtx, pData, nSize);
+		int nError = EVP_DigestSignInit(pCtx, NULL, pDigest, NULL, m_key);
+		nError = EVP_DigestSignUpdate(pCtx, pData, nSize);
 
 		BYTE pSignature[4096];
-		unsigned int nSignatureLen = 0;
+		size_t nSignatureLen = sizeof(pSignature);
 
-		nError = EVP_SignFinal(pCtx, pSignature, &nSignatureLen, m_key);
+		nError = EVP_DigestSignFinal(pCtx, pSignature, &nSignatureLen);
 
-		EVP_MD_CTX_destroy(pCtx);
+		EVP_MD_CTX_free(pCtx);
 
 		if (nSignatureLen > 0)
 		{
@@ -830,22 +852,21 @@ public:
 			return (1 == nVer) ? true : false;
 		}
 
-		EVP_MD_CTX* pCtx = EVP_MD_CTX_create();
+		EVP_MD_CTX* pCtx = EVP_MD_CTX_new();
 		const EVP_MD* pDigest = Get_EVP_MD(nAlg);
 
-		int n1 = EVP_VerifyInit(pCtx, pDigest);
+		EVP_PKEY* pubkey = X509_get_pubkey(m_cert);
 
 		BYTE* pDigestValue = NULL;
 		int nDigestLen = 0;
 		NSFile::CBase64Converter::Decode(sXmlSignature.c_str(), (int)sXmlSignature.length(), pDigestValue, nDigestLen);
 
-		int n2 = EVP_VerifyUpdate(pCtx, (BYTE*)sXml.c_str(), (size_t)sXml.length());
+		EVP_DigestVerifyInit(pCtx, NULL, pDigest, NULL, pubkey);
+		EVP_DigestVerifyUpdate(pCtx, (BYTE*)sXml.c_str(), (size_t)sXml.length());
 
-		EVP_PKEY* pubkey = X509_get_pubkey(m_cert);
+		int n3 = EVP_DigestVerifyFinal(pCtx, pDigestValue, (size_t)nDigestLen);
 
-		int n3 = EVP_VerifyFinal(pCtx, pDigestValue, (unsigned int)nDigestLen, pubkey);
-
-		EVP_MD_CTX_destroy(pCtx);
+		EVP_MD_CTX_free(pCtx);
 		EVP_PKEY_FREE(pubkey);
 
 		RELEASEARRAYOBJECTS(pDigestValue);

--- a/HwpFile/HWPFile.pro
+++ b/HwpFile/HWPFile.pro
@@ -12,12 +12,11 @@ PWD_ROOT_DIR = $$PWD
 
 include($$CORE_ROOT_DIR/Common/base.pri)
 
-LIBS += -L$$CORE_BUILDS_LIBRARIES_PATH -lCryptoPPLib
+include($$CORE_ROOT_DIR/Common/3dParty/cryptopp/cryptopp.pri)
 
 ADD_DEPENDENCY(kernel, UnicodeConverter, graphics, StarMathConverter)
 
-DEFINES += HWPFILE_USE_DYNAMIC_LIBRARY \
-           CRYPTOPP_DISABLE_ASM 
+DEFINES += HWPFILE_USE_DYNAMIC_LIBRARY
 
 
 SOURCES += \

--- a/HwpFile/HwpDoc/HWPFile.cpp
+++ b/HwpFile/HwpDoc/HWPFile.cpp
@@ -5,9 +5,9 @@
 #include "../DesktopEditor/common/Directory.h"
 
 // For decrypt
-#include "../../Common/3dParty/cryptopp/modes.h"
-#include "../../Common/3dParty/cryptopp/aes.h"
-#include "../../Common/3dParty/cryptopp/filters.h"
+#include <cryptopp/modes.h>
+#include <cryptopp/aes.h>
+#include <cryptopp/filters.h>
 // ----------
 
 #define DEFAULT_BUFFER_SIZE 8096

--- a/OOXML/test/test.pro
+++ b/OOXML/test/test.pro
@@ -6,6 +6,7 @@ DEFINES += BUILD_X2T_AS_LIBRARY_DYLIB
 
 X2T_DIR = $$PWD/../../X2tConverter
 
+CONFIG += core_no_gtest_main
 include($$X2T_DIR/build/Qt/X2tConverter.pri)
 include($$X2T_DIR/../Common/3dParty/googletest/googletest.pri)
 
@@ -22,7 +23,6 @@ HEADERS += common.h
 DESTDIR = $$CORE_BUILDS_BINARY_PATH
 
 
-SOURCES -= $$CORE_GTEST_PATH/src/gtest_main.cc
 SOURCES -= ../../../Common/OfficeFileFormatChecker2.cpp
 SOURCES -= ../../src/cextracttools.cpp
 SOURCES -= ../../src/ASCConverters.cpp

--- a/OdfFile/Test/test_odf/test_odf.pro
+++ b/OdfFile/Test/test_odf/test_odf.pro
@@ -9,6 +9,7 @@ CONFIG   -= app_bundle
 
 CONFIG += core_static_link_libstd
 CONFIG += build_x2t_as_library
+CONFIG += core_no_gtest_main
 
 CORE_ROOT_DIR = $$PWD/../../../../core
 
@@ -37,4 +38,3 @@ SOURCES += \
 #    audio.cpp\
 #    interactions.cpp
 
-SOURCES -= $$CORE_GTEST_PATH/src/gtest_main.cc

--- a/OdfFile/Writer/Format/object_package.cpp
+++ b/OdfFile/Writer/Format/object_package.cpp
@@ -41,7 +41,7 @@
 #include "../../../DesktopEditor/common/SystemUtils.h"
 
 #include "../../../OOXML/SystemUtility/SystemUtility.h"
-#include "../../../Common/3dParty/cryptopp/osrng.h"
+#include <cryptopp/osrng.h>
 
 namespace cpdoccore 
 {

--- a/OfficeCryptReader/Test/test.pro
+++ b/OfficeCryptReader/Test/test.pro
@@ -10,15 +10,14 @@ PWD_ROOT_DIR = $$PWD
 include($$CORE_ROOT_DIR/Common/base.pri)
 include($$CORE_ROOT_DIR/Common/3dParty/boost/boost.pri)
 
-LIBS += -L$$CORE_BUILDS_LIBRARIES_PATH -lCryptoPPLib -lCompoundFileLib
+include($$CORE_ROOT_DIR/Common/3dParty/cryptopp/cryptopp.pri)
+LIBS += -L$$CORE_BUILDS_LIBRARIES_PATH -lCompoundFileLib
 ADD_DEPENDENCY(UnicodeConverter, kernel)
 
 include($$CORE_ROOT_DIR/Common/3dParty/icu/icu.pri)
 
 CONFIG += open_ssl_common
 include($$CORE_ROOT_DIR/Common/3dParty/openssl/openssl.pri)
-
-DEFINES += CRYPTOPP_DISABLE_ASM
 DESTDIR = $$CORE_BUILDS_BINARY_PATH
 
 HEADERS += \

--- a/OfficeCryptReader/ooxml_crypt/ooxml_crypt.pro
+++ b/OfficeCryptReader/ooxml_crypt/ooxml_crypt.pro
@@ -10,15 +10,14 @@ PWD_ROOT_DIR = $$PWD
 include($$CORE_ROOT_DIR/Common/base.pri)
 include($$CORE_ROOT_DIR/Common/3dParty/boost/boost.pri)
 
-LIBS += -L$$CORE_BUILDS_LIBRARIES_PATH -lCryptoPPLib -lCompoundFileLib
+include($$CORE_ROOT_DIR/Common/3dParty/cryptopp/cryptopp.pri)
+LIBS += -L$$CORE_BUILDS_LIBRARIES_PATH -lCompoundFileLib
 ADD_DEPENDENCY(UnicodeConverter, kernel)
 
 include($$CORE_ROOT_DIR/Common/3dParty/icu/icu.pri)
 
 CONFIG += open_ssl_common
 include($$CORE_ROOT_DIR/Common/3dParty/openssl/openssl.pri)
-
-DEFINES += CRYPTOPP_DISABLE_ASM
 DESTDIR = $$CORE_BUILDS_BINARY_PATH
 
 HEADERS += \

--- a/OfficeCryptReader/source/CryptTransform.cpp
+++ b/OfficeCryptReader/source/CryptTransform.cpp
@@ -36,22 +36,22 @@
 
 #include "CryptTransform.h"
 
-#include "../../Common/3dParty/cryptopp/modes.h"
-#include "../../Common/3dParty/cryptopp/aes.h"
-#include "../../Common/3dParty/cryptopp/des.h"
-#include "../../Common/3dParty/cryptopp/sha.h"
-#include "../../Common/3dParty/cryptopp/md5.h"
-#include "../../Common/3dParty/cryptopp/rsa.h"
-#include "../../Common/3dParty/cryptopp/rc2.h"
-#include "../../Common/3dParty/cryptopp/arc4.h"
-#include "../../Common/3dParty/cryptopp/rc5.h"
-#include "../../Common/3dParty/cryptopp/pwdbased.h"
-#include "../../Common/3dParty/cryptopp/filters.h"
-#include "../../Common/3dParty/cryptopp/osrng.h"
-#include "../../Common/3dParty/cryptopp/hex.h"
-#include "../../Common/3dParty/cryptopp/blowfish.h"
-#include "../../Common/3dParty/cryptopp/zinflate.h"
-#include "../../Common/3dParty/cryptopp/zdeflate.h"
+#include <cryptopp/modes.h>
+#include <cryptopp/aes.h>
+#include <cryptopp/des.h>
+#include <cryptopp/sha.h>
+#include <cryptopp/md5.h>
+#include <cryptopp/rsa.h>
+#include <cryptopp/rc2.h>
+#include <cryptopp/arc4.h>
+#include <cryptopp/rc5.h>
+#include <cryptopp/pwdbased.h>
+#include <cryptopp/filters.h>
+#include <cryptopp/osrng.h>
+#include <cryptopp/hex.h>
+#include <cryptopp/blowfish.h>
+#include <cryptopp/zinflate.h>
+#include <cryptopp/zdeflate.h>
 
 #include "../../OOXML/Base/unicode_util.h"
 #include "../../OOXML/Base/Base.h"

--- a/OfficeUtils/OfficeUtils.pri
+++ b/OfficeUtils/OfficeUtils.pri
@@ -12,8 +12,18 @@ build_zlib_as_sources {
 
 INCLUDEPATH += \
     $$PWD/src/zlib-1.2.11/contrib/minizip \
-    $$PWD/src/zlib-1.2.11 \
     $$PWD/src
+
+use_system_zlib {
+    # Force-include zlib_addon.h so vendored minizip sources (unzip.c,
+    # iowin32.c) see the addon flags that the vendored zlib.h normally
+    # pulls in.
+    QMAKE_CFLAGS += -include $$PWD/src/zlib_addon.h
+    QMAKE_CXXFLAGS += -include $$PWD/src/zlib_addon.h
+    LIBS += -lz
+} else {
+    INCLUDEPATH += $$PWD/src/zlib-1.2.11
+}
 
 SOURCES +=  \
     $$PWD/src/OfficeUtils.cpp \
@@ -31,7 +41,7 @@ core_windows {
 SOURCES +=  \
     $$PWD/src/zlib-1.2.11/contrib/minizip/iowin32.c
 }
-build_all_zlib {
+!use_system_zlib:build_all_zlib {
 SOURCES += \
     $$PWD/src/zlib-1.2.11/adler32.c \
     $$PWD/src/zlib-1.2.11/compress.c \

--- a/OfficeUtils/src/zlib-1.2.11/contrib/minizip/ioapibuf.h
+++ b/OfficeUtils/src/zlib-1.2.11/contrib/minizip/ioapibuf.h
@@ -1,6 +1,5 @@
 #include <string.h>
 
-#include "../../zlib.h"
 #include "ioapi.h"
 
 #ifdef __cplusplus

--- a/OfficeUtils/src/zlib_addon.h
+++ b/OfficeUtils/src/zlib_addon.h
@@ -37,5 +37,19 @@
 #define ZLIB_ADDON_FLAG_WINDOWS_SHARED_WRITE    2
 #endif
 
-void zlip_set_addition_flag(int flag);
-int zlip_get_addition_flag();
+#if defined(__GNUC__) && __GNUC__ >= 4
+#define ZLIB_ADDON_EXPORT __attribute__((visibility("default")))
+#else
+#define ZLIB_ADDON_EXPORT
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+ZLIB_ADDON_EXPORT void zlip_set_addition_flag(int flag);
+ZLIB_ADDON_EXPORT int zlip_get_addition_flag();
+
+#ifdef __cplusplus
+}
+#endif

--- a/PdfFile/PdfFile.pro
+++ b/PdfFile/PdfFile.pro
@@ -109,9 +109,8 @@ use_external_jpeg2000 {
 }
 
 # PdfWriter
-DEFINES += CRYPTOPP_DISABLE_ASM \
-           NOMINMAX
-LIBS += -L$$CORE_BUILDS_LIBRARIES_PATH -lCryptoPPLib
+DEFINES += NOMINMAX
+include($$CORE_ROOT_DIR/Common/3dParty/cryptopp/cryptopp.pri)
 
 core_linux {
     DEFINES += HAVE_UNISTD_H \

--- a/PdfFile/SrcWriter/Encrypt.cpp
+++ b/PdfFile/SrcWriter/Encrypt.cpp
@@ -32,13 +32,13 @@
 #include "Encrypt.h"
 #include "Objects.h"
 
-#include "../../Common/3dParty/cryptopp/modes.h"
-#include "../../Common/3dParty/cryptopp/aes.h"
-#include "../../Common/3dParty/cryptopp/sha.h"
-#include "../../Common/3dParty/cryptopp/md5.h"
-#include "../../Common/3dParty/cryptopp/arc4.h"
-#include "../../Common/3dParty/cryptopp/filters.h"
-#include "../../Common/3dParty/cryptopp/osrng.h"
+#include <cryptopp/modes.h>
+#include <cryptopp/aes.h>
+#include <cryptopp/sha.h>
+#include <cryptopp/md5.h>
+#include <cryptopp/arc4.h>
+#include <cryptopp/filters.h>
+#include <cryptopp/osrng.h>
 
 namespace PdfWriter
 {

--- a/PdfFile/SrcWriter/EncryptDictionary.cpp
+++ b/PdfFile/SrcWriter/EncryptDictionary.cpp
@@ -36,7 +36,7 @@
 
 #include <ctime>
 
-#include "../../Common/3dParty/cryptopp/md5.h"
+#include <cryptopp/md5.h>
 #include "../../UnicodeConverter/UnicodeConverter.h"
 
 #define SET_BINARY_PARAM(Name, set_func, max_len) \

--- a/TxtFile/Source/PptxTxtConverterTest/PptxTxtConverterTest.pro
+++ b/TxtFile/Source/PptxTxtConverterTest/PptxTxtConverterTest.pro
@@ -36,7 +36,7 @@ LIBS += -L$$CORE_BUILDS_LIBRARIES_PATH -lDocxFormatLib
 LIBS += -L$$CORE_BUILDS_LIBRARIES_PATH -lXlsbFormatLib
 LIBS += -L$$CORE_BUILDS_LIBRARIES_PATH -lXlsFormatLib
 LIBS += -L$$CORE_BUILDS_LIBRARIES_PATH -lCompoundFileLib
-LIBS += -L$$CORE_BUILDS_LIBRARIES_PATH -lCryptoPPLib
+include($$CORE_ROOT_DIR/Common/3dParty/cryptopp/cryptopp.pri)
 
 ADD_DEPENDENCY(graphics, kernel, UnicodeConverter, kernel_network, Fb2File, PdfFile, HtmlFile2, EpubFile, XpsFile, OFDFile, DjVuFile, doctrenderer, DocxRenderer, IWorkFile, HWPFile)
 

--- a/X2tConverter/test/TestOOOXml2Odf/TestOOOXml2Odf.pro
+++ b/X2tConverter/test/TestOOOXml2Odf/TestOOOXml2Odf.pro
@@ -27,7 +27,7 @@ INCLUDEPATH += $$CORE_ROOT_DIR/Common
 INCLUDEPATH += $$CORE_ROOT_DIR/OOXML/PPTXFormat/Logic
 
 
-LIBS += -L$$CORE_BUILDS_LIBRARIES_PATH -lCryptoPPLib 
+include($$CORE_ROOT_DIR/Common/3dParty/cryptopp/cryptopp.pri)
 LIBS += -L$$CORE_BOOST_LIBS
 
 win32 {


### PR DESCRIPTION
## Summary

This PR makes it possible to build OnlyOffice core against system-provided libraries and modern toolchains, enabling proper distribution packaging (e.g. openSUSE/Fedora RPMs) instead of relying solely on vendored/bundled dependencies.

### OpenSSL 3.x compatibility
- Migrate RSA key generation from deprecated `RSA_new()`/`RSA_generate_multi_prime_key()` to the `EVP_PKEY_CTX` interface, which works on both OpenSSL 1.1.x and 3.x ([migration guide](https://docs.openssl.org/3.0/man7/migration_guide/))
- Remove redundant `EVP_CIPHER_CTX_init()` calls (`EVP_CIPHER_CTX_new()` already zero-initializes) and no-op `EVP_cleanup()` calls ([docs](https://docs.openssl.org/3.0/man3/OpenSSL_add_all_algorithms/))
- Update hash implementation in doctrenderer to use modern EVP digest API
- Handle unsupported hash algorithms gracefully in `HashEmbed`

### V8 12.1+ compatibility
- Add `V8Holder` compat macro (`This()` on 12.1+, `Holder()` on older V8)
- Guard `VisitHandlesWithClassIds()` removal and inspector `connect()` API changes behind `V8_VERSION_121_PLUS`
- Use `v8::Isolate::GetCurrent()` instead of removed `Context::GetIsolate()`

### GCC 14/15 fixes
- Fix `-Wincompatible-pointer-types` errors in vendored jasper (`int*` vs `jpc_fix_t*`)
- Replace wide string literals in `pole.cpp` that GCC 15 libstdc++ rejects (`operator<<(ostream, wchar_t*)` deleted)

### System library support (`CONFIG+=use_system_*`)
Add `use_system_*` qmake config flags to link against system-installed packages instead of vendored copies:
- **OpenSSL**: `use_system_openssl`
- **zlib**: `use_system_zlib` (keeps vendored minizip with OnlyOffice-specific patches)
- **Crypto++**: `use_system_cryptopp` — also normalizes include paths to portable `<cryptopp/foo.h>` form
- **Boost**: `use_system_boost`
- **ICU**: `use_system_icu`
- **HarfBuzz**: `use_system_harfbuzz`
- **libheif**: `use_system_heif` — also switches to portable `<libheif/heif.h>` include
- **V8**: `use_system_v8` — targets V8 from system packages (e.g. `nodejs-22-libv8`)

### Other fixes
- Export `zlib_addon` symbols with proper C linkage and visibility for shared library builds
- Remove redundant vendored `zlib.h` include from `ioapibuf.h`