### PR TITLE
Fix CCITT Fax3/Fax4 decoder heap overflow in vendored libtiff (CVE-2011-0192)

### DIFF
--- a/DesktopEditor/cximage/tiff/tif_fax3.h
+++ b/DesktopEditor/cximage/tiff/tif_fax3.h
@@ -478,6 +478,12 @@ done1d:									\
 	    break;							\
 	case S_VL:							\
 	    CHECK_b1;							\
+	    if (b1 <= (int) (a0 + TabEnt->Param)) {			\
+		if (b1 < (int) (a0 + TabEnt->Param) || pa != thisrun) {	\
+		    unexpected("VL", a0);				\
+		    goto eol2d;						\
+		}							\
+	    }								\
 	    SETVALUE(b1 - a0 - TabEnt->Param);				\
 	    b1 -= *--pb;						\
 	    break;							\


### PR DESCRIPTION
## Summary

The vendored libtiff **3.9.4** (2010) CCITT Fax3/Fax4 decoder in `DesktopEditor/cximage/tiff/` is vulnerable to a heap buffer overflow (**CVE-2011-0192**). This PR backports the official upstream fix (libtiff 3.9.5) as a single-file, surgical change to `DesktopEditor/cximage/tiff/tif_fax3.h`.

## The bug

`Fax4Decode` (and the other 2-D decoders) expand runs through the `EXPAND2D` macro in `tif_fax3.h`. The `S_VL` (vertical-left) case writes a decoded run via `SETVALUE` / `*pa++` **without validating** the new changing-element position against the reference line. A crafted CCITT G3/G4 stream can drive the run array (`runs[]`, sized once in `Fax3SetupState`) past its end, yielding a **heap-buffer-overflow WRITE** in `Fax4Decode`.

ASan backtrace (vendored 3.9.4 sources, exact API ONLYOFFICE calls):

```
WRITE of size 4 ... heap-buffer-overflow in Fax4Decode (tif_fax3.c, EXPAND2D)
  Fax4Decode -> TIFFReadEncodedStrip -> gtStripContig
  -> TIFFRGBAImageGet -> TIFFReadRGBAImageOriented -> TIFFReadRGBAImage
buffer allocated in Fax3SetupState (runs[])
```

## Reachability in this codebase

A TIFF embedded in (or opened as) an untrusted document is decoded by CxImage → libtiff:

- `DesktopEditor/raster/ImageFileFormatChecker.cpp` sniffs the TIFF magic (`II*` / `MM*`) — by content, not extension.
- `CBgraFrame::OpenFile/Decode` → `CxImage::Decode(_CXIMAGE_FORMAT_TIF)` → `CxImageTIF::Decode` (`ximatif.cpp`), which calls `TIFFReadRGBAImage` (ximatif.cpp:175) — the exact sink that overflows.
- `CBgraFrame` is fed by document-conversion image managers (OOXML/PPTX `imagemanager.cpp`, RTF `RtfPicture.cpp`, FB2/HTML/PDF, WMF/EMF blips, …).

So a malicious image inside a DOCX/PPTX/RTF/FB2/HTML/PDF processed during conversion/rendering reaches the vulnerable decoder.

## The fix

Backport of the upstream libtiff 3.9.5 guard in the `EXPAND2D` `S_VL` case — reject the unexpected VL transition instead of writing out of bounds:

```c
case S_VL:
    CHECK_b1;
    if (b1 <= (int) (a0 + TabEnt->Param)) {
        if (b1 < (int) (a0 + TabEnt->Param) || pa != thisrun) {
            unexpected("VL", a0);
            goto eol2d;
        }
    }
    SETVALUE(b1 - a0 - TabEnt->Param);
    b1 -= *--pb;
    break;
```

Note: although the crash *manifests* in `Fax4Decode` (`tif_fax3.c`), the `EXPAND2D` macro and the upstream fix both live in `tif_fax3.h`, so the change is confined to that header (matching upstream exactly).

## Verification

Built the vendored 3.9.4 tiff sources with `clang -fsanitize=address` and exercised the same `TIFFReadRGBAImage` path as `CxImageTIF::Decode`:

| input | before (3.9.4) | after (this patch) |
|---|---|---|
| PoC G4 TIFF | ASan heap-buffer-overflow WRITE, abort | exit 0, graceful "Bad code word / Premature EOL" rejection, **no ASan error** |
| valid G4 TIFF (64×48) | decodes | decodes (no regression) |

## Important: this is a stopgap

The vendored libtiff here is **3.9.4 (2010)**. It still carries many other pre-4.0 libtiff CVEs beyond this one; a single backport does not make it safe. **Strongly recommend upgrading the vendored CxImage libtiff to a current 4.x release** (and ideally consolidating with the 4.x copy already present under `DesktopEditor/raster/Jp2/openjpeg/.../thirdparty/libtiff`). This PR is a minimal, low-risk mitigation for the one reachable heap-write in the meantime.

Refs: CVE-2011-0192; upstream libtiff 3.9.5 `tif_fax3.h` fix.
