### PR TITLE
Fix <mergeCell> shorthand notation to prevent Google Sheets/Drive parser breakdown

### DIFF
--- a/OOXML/XlsxFormat/Worksheets/MergeCells.cpp
+++ b/OOXML/XlsxFormat/Worksheets/MergeCells.cpp
@@ -61,9 +61,60 @@ namespace OOX
 		}
 		void CMergeCell::toXML(NSStringUtils::CStringBuilder& writer) const
 		{
-			writer.WriteString(_T("<mergeCell"));
-			WritingStringNullableAttrEncodeXmlString(L"ref", m_oRef, m_oRef.get());
-			writer.WriteString(_T("/>"));
+		    writer.WriteString(_T("<mergeCell"));
+		    
+		    // 1. Extract the current reference string. 
+		    // If it's not initialized, fallback to an empty string.
+		    std::wstring sFinalRef = m_oRef.IsInit() ? m_oRef.get() : L"";
+		
+		    // 2. Process only if there is a valid reference string.
+		    if (!sFinalRef.empty())
+		    {
+		        // Look for the colon ':' that acts as the delimiter in a cell range.
+		        size_t nColon = sFinalRef.find(L':');
+		        if (nColon != std::wstring::npos)
+		        {
+		            // Split the string into left and right boundaries.
+		            // e.g., in "A:C", sLeft is "A" and sRight is "C".
+		            // e.g., in "1:2", sLeft is "1" and sRight is "2".
+		            std::wstring sLeft = sFinalRef.substr(0, nColon);
+		            std::wstring sRight = sFinalRef.substr(nColon + 1);
+		
+		            bool bIsAlpha = true, bIsDigit = true;
+		            
+		            // 3. Validation: Check if the range consists EXCLUSIVELY of letters.
+		            // This indicates a full-column merge (shorthand notation).
+		            for (wchar_t c : sLeft)  if (!iswalpha(c)) bIsAlpha = false;
+		            for (wchar_t c : sRight) if (!iswalpha(c)) bIsAlpha = false;
+		            
+		            // 4. Validation: Check if the range consists EXCLUSIVELY of numbers.
+		            // This indicates a full-row merge (shorthand notation).
+		            for (wchar_t c : sLeft)  if (!iswdigit(c)) bIsDigit = false;
+		            for (wchar_t c : sRight) if (!iswdigit(c)) bIsDigit = false;
+		
+		            // 5. Dynamic Strict Formatting Application:
+		            // Stricter parsers (like Google Sheets/Drive) do not support shorthand notations 
+		            // inside the <mergeCell> tag and require explicit grid boundaries.
+		            if (bIsAlpha && !sLeft.empty() && !sRight.empty())
+		            {
+		                // Convert full-column range to strict boundaries.
+		                // It appends row 1 to the left side and the maximum Excel row (1048576) to the right.
+		                // Result example: "A:C" becomes "A1:C1048576".
+		                sFinalRef = sLeft + L"1:" + sRight + L"1048576";
+		            }
+		            else if (bIsDigit && !sLeft.empty() && !sRight.empty())
+		            {
+		                // Convert full-row range to strict boundaries.
+		                // It prepends column A to the left side and the maximum Excel column (XFD) to the right.
+		                // Result example: "1:2" becomes "A1:XFD2".
+		                sFinalRef = L"A" + sLeft + L":XFD" + sRight;
+		            }
+		        }
+		    }
+		
+		    // 6. Write the final strict reference string to the XML output.
+		    WritingStringNullableAttrEncodeXmlString(L"ref", m_oRef, sFinalRef);
+		    writer.WriteString(_T("/>"));
 		}
 		void CMergeCell::fromXML(XmlUtils::CXmlLiteReader& oReader)
 		{


### PR DESCRIPTION
**The problem:**
Currently, when a user merges entire rows or columns, ONLYOFFICE uses the shorthand OOXML notation (e.g., 1:1 or A:A) inside the `<mergeCell>` tag. While this is technically valid, Google Sheets/Drive expects strict grid boundaries (e.g., A1:XFD1) and lacks a fallback mechanism. As a result, opening these .xlsx files in Google Sheets fails to load the spreadsheet completely.
So, this commit introduces a dynamic interceptor in CMergeCell::toXML. Instead of modifying the core math utility — which could risk breaking formula references that rely on shorthand notations (like =SUM(A:A)) — this fix acts exclusively during the XML serialization of the `<mergeCell>` tag.
It splits the string, checks if it consists purely of digits (rows) or purely of letters (columns), and dynamically expands it to the maximum supported grid boundaries (A to XFD for rows, 1 to 1048576 for columns). Standard ranges (like A1:B2) are ignored by the conditional and processed normally. This ensures 100% parity with Microsoft Excel's XML output and restores full Google Drive compatibility.

**Actual behavior:**
Google Sheets fails to interpret the merged cells properly and doesn't load it at all. If you unzip the .xlsx file and inspect xl/worksheets/sheet1.xml, the merge is recorded using shorthand notation (e.g., `<mergeCell ref="1:1"/>` or `<mergeCell ref="A:A"/>`).

<img width="2560" height="1440" alt="Captura de tela de 2026-07-03 10-56-06" src="https://github.com/user-attachments/assets/1c8b13b4-81c7-40fd-9dc9-a74569e861a6" />

<img width="2740" height="1840" alt="Captura de tela de 2026-07-03 10-57-21" src="https://github.com/user-attachments/assets/39c50d83-c3b9-4042-9ab4-599273af811a" />

<img width="2740" height="1840" alt="Captura de tela de 2026-07-03 10-57-58" src="https://github.com/user-attachments/assets/0f6599ca-5ddb-4815-b7a5-cc1a12596381" />

**Steps to reproduce:**
- Open ONLYOFFICE Spreadsheet editor and create a new blank spreadsheet;
- Select an entire row (e.g., click on the row header letter or column number (e.g., click on the column header A);
- Click the Merge Cells button on the top toolbar;
- Save the document locally as an .xlsx file;
- Upload the saved .xlsx file to Google Drive;
- Attempt to open the file using Google Sheets (on your browser or the Android/iOS app).

**Expected behavior (with this PR):**
The file opens flawlessly in Google Sheets, maintaining the merged rows/columns. Inspecting the XML reveals that the shorthand notation was dynamically converted to strict grid boundaries (e.g., `<mergeCell ref="A1:XFD1"/>` or `<mergeCell ref="A1:A1048576"/>`), achieving 100% parity with Microsoft Excel's serialization standard.

<img width="2740" height="1840" alt="Captura de tela de 2026-07-03 11-02-22" src="https://github.com/user-attachments/assets/e4bb3367-ad17-469a-81ee-878ead9a5605" />

<img width="2740" height="1840" alt="Captura de tela de 2026-07-03 11-02-47" src="https://github.com/user-attachments/assets/f8ea6493-0116-48e0-8439-479a718a5147" />

