### PR TITLE
Fix crash when converting PPT with empty audio relationships

### DIFF
--- a/MsBinaryFile/PptFile/Converter/Animation/Timing_2010.cpp
+++ b/MsBinaryFile/PptFile/Converter/Animation/Timing_2010.cpp
@@ -949,9 +949,12 @@ void Timing_2010::FillAudio(CRecordExtTimeNodeContainer *pETNC, PPTX::Logic::Aud
         if (pInfo1)
         {
             bool bExternal(false);
-            oAudio.cMediaNode.tgtEl.embed =
-                    new OOX::RId(m_pRels->WriteAudio(pInfo1->m_strFilePath, bExternal));
-            oAudio.cMediaNode.tgtEl.name = XmlUtils::EncodeXmlString(pInfo1->m_name);
+            std::wstring audioRid = m_pRels->WriteAudio(pInfo1->m_strFilePath, bExternal);
+            if (!audioRid.empty())
+            {
+                oAudio.cMediaNode.tgtEl.embed = new OOX::RId(audioRid);
+                oAudio.cMediaNode.tgtEl.name = XmlUtils::EncodeXmlString(pInfo1->m_name);
+            }
         } else if (pCVEC->m_oVisualShapeAtom.m_RefType == TL_ET_ShapeType)
         {
             oAudio.cMediaNode.tgtEl.spTgt = new PPTX::Logic::SpTgt;
@@ -972,9 +975,12 @@ void Timing_2010::FillAudio(CRecordClientVisualElementContainer *pCVEC, PPTX::Lo
         if (pInfo1 && m_pRels)
         {
             bool bExternal(false);
-            oAudio.cMediaNode.tgtEl.embed =
-                    new OOX::RId(m_pRels->WriteAudio(pInfo1->m_strFilePath, bExternal));
-            oAudio.cMediaNode.tgtEl.name = XmlUtils::EncodeXmlString(pInfo1->m_name);
+            std::wstring audioRid = m_pRels->WriteAudio(pInfo1->m_strFilePath, bExternal);
+            if (!audioRid.empty())
+            {
+                oAudio.cMediaNode.tgtEl.embed = new OOX::RId(audioRid);
+                oAudio.cMediaNode.tgtEl.name = XmlUtils::EncodeXmlString(pInfo1->m_name);
+            }
         }
     }
 }

--- a/MsBinaryFile/PptFile/Converter/transition.cpp
+++ b/MsBinaryFile/PptFile/Converter/transition.cpp
@@ -253,8 +253,13 @@ void Transition::ConvertAudioEffect()
 {
     if (HasAudio() == false) return;
 
+    // Resolve media first; skip sound if WriteAudio refused (empty/unresolvable path).
+    std::wstring rId = GetAudioRId();
+    if (rId.empty())
+        return;
+
     InitSound();
-    WriteAudioRId();
+    newTransition.sndAc->stSnd->embed = rId;
     WriteSoundName();
 }
 
@@ -277,7 +282,11 @@ void Transition::InitSound()
 
 bool Transition::HasAudio() const
 {
-    return oldTransition.m_bAudioPresent == true && pRels != nullptr;
+    // m_bAudioPresent alone is not enough: some PPTs set the flag with an empty path,
+    // which used to emit Target="" audio relationships and crash editor open.
+    return oldTransition.m_bAudioPresent == true
+        && pRels != nullptr
+        && !oldTransition.m_oAudio.m_strAudioFileName.empty();
 }
 
 void Transition::WriteSoundName()

--- a/MsBinaryFile/PptFile/PPTXWriter/ImageManager.cpp
+++ b/MsBinaryFile/PptFile/PPTXWriter/ImageManager.cpp
@@ -487,12 +487,26 @@ std::wstring CRelsGenerator::WriteSlideRef(const std::wstring &strLocation)
 
 std::wstring CRelsGenerator::WriteAudio(const std::wstring &strAudioPath, bool &bExternal)
 {
+    // Empty path must not emit Target="" relationships — OpenFileToPPTY SIGSEGVs on them
+    // (e.g. PPT transition sound flag with no resolved media; see file_example_PPT_1MB.ppt).
+    if (strAudioPath.empty())
+    {
+        bExternal = false;
+        return L"";
+    }
+
     std::wstring strAudio = m_pManager->GenerateAudio(strAudioPath);
 
     if (strAudio.empty())
     {
+        std::wstring corrected = CorrectXmlString3(strAudioPath);
+        if (corrected.empty())
+        {
+            bExternal = false;
+            return L"";
+        }
         bExternal = true;
-        return WriteHyperlinkAudio(CorrectXmlString3(strAudioPath), true);
+        return WriteHyperlinkAudio(corrected, true);
     }
     else
     {
@@ -502,12 +516,24 @@ std::wstring CRelsGenerator::WriteAudio(const std::wstring &strAudioPath, bool &
 
 std::wstring CRelsGenerator::WriteVideo(const std::wstring &strVideoPath, bool &bExternal)
 {
+    if (strVideoPath.empty())
+    {
+        bExternal = false;
+        return L"";
+    }
+
     std::wstring strVideo = m_pManager->GenerateVideo(strVideoPath);
 
     if (strVideo.empty())
     {
+        std::wstring corrected = CorrectXmlString3(strVideoPath);
+        if (corrected.empty())
+        {
+            bExternal = false;
+            return L"";
+        }
         bExternal = true;
-        return WriteHyperlinkVideo(CorrectXmlString3(strVideoPath), true);
+        return WriteHyperlinkVideo(corrected, true);
     }
     else
     {

--- a/MsBinaryFile/PptFile/PPTXWriter/ShapeWriter.cpp
+++ b/MsBinaryFile/PptFile/PPTXWriter/ShapeWriter.cpp
@@ -621,9 +621,11 @@ void PPT::CShapeWriter::WriteImageInfo()
         bool bExternal = false;
         std::wstring strRid = m_pRels->WriteVideo(pVideoElement->m_strVideoFileName, bExternal);
 
-        m_oWriter.WriteString(L"<a:videoFile r:link=\"" + strRid + L"\"/>");
-
-        sMediaFile = bExternal ? L"" : pVideoElement->m_strVideoFileName;
+        if (!strRid.empty())
+        {
+            m_oWriter.WriteString(L"<a:videoFile r:link=\"" + strRid + L"\"/>");
+            sMediaFile = bExternal ? L"" : pVideoElement->m_strVideoFileName;
+        }
     }
 
     if ((pAudioElement) && (!pAudioElement->m_strAudioFileName.empty()))
@@ -631,13 +633,16 @@ void PPT::CShapeWriter::WriteImageInfo()
         bool bExternal = false;
         std::wstring strRid = m_pRels->WriteAudio(pAudioElement->m_strAudioFileName, bExternal);
 
+        if (!strRid.empty())
+        {
 //        if ((int)pAudioElement->m_strAudioFileName.find(L".WAV") == -1 &&
 //                (int)pAudioElement->m_strAudioFileName.find(L".wav") == -1)
 //            m_oWriter.WriteString(L"<a:wavAudioFile r:embed=\"" + strRid + L"\"/>");
 //        else
             m_oWriter.WriteString(L"<a:audioFile r:link=\"" + strRid + L"\"/>"); // todo for anim connection
 
-        sMediaFile = bExternal ? L"" : pAudioElement->m_strAudioFileName;
+            sMediaFile = bExternal ? L"" : pAudioElement->m_strAudioFileName;
+        }
     }
     if (sMediaFile.empty() == false)
     {
@@ -1658,12 +1663,16 @@ void PPT::CShapeWriter::WriteHyperlink(const std::vector<CInteractiveInfo>& acti
 
         if (actions[i].m_strAudioFileName.size() && m_pRels)
         {
-            hlink.snd = new PPTX::Logic::WavAudioFile;
             bool bExternal = false;
-            hlink.snd->embed = m_pRels->WriteAudio(actions[i].m_strAudioFileName, bExternal);
-            hlink.snd->m_name = L"snd";
-            hlink.snd->name = actions[i].m_strAudioName;
-            hlink.id = std::wstring(L"");
+            std::wstring audioRid = m_pRels->WriteAudio(actions[i].m_strAudioFileName, bExternal);
+            if (!audioRid.empty())
+            {
+                hlink.snd = new PPTX::Logic::WavAudioFile;
+                hlink.snd->embed = audioRid;
+                hlink.snd->m_name = L"snd";
+                hlink.snd->name = actions[i].m_strAudioName;
+                hlink.id = std::wstring(L"");
+            }
         }
 
         if (actions[i].m_eActivation == CInteractiveInfo::over)


### PR DESCRIPTION
Fix for PowerPoint 97-2003 

Skip empty or unresolvable media paths in WriteAudio/WriteVideo and transition sound conversion so Target="" relationships are not emitted and OpenFileToPPTY no longer SIGSEGVs.

Mostly use !audioRid.empty() check beforehand.

Test file: https://www.scribd.com/presentation/556594257/File-Example-PPT-1MB