### PR TITLE
fix(fonts): add standard fonts to the font list via installed substitutes

### DIFF
--- a/DesktopEditor/fontengine/ApplicationFontsWorker.cpp
+++ b/DesktopEditor/fontengine/ApplicationFontsWorker.cpp
@@ -686,6 +686,50 @@ public:
 		}
 		// -------------------------------------------
 
+		// add standard fonts that are not installed, mapping them to their best installed
+		// substitute, so that they remain available in the font list (e.g. "Times New Roman"
+		// on Linux, where Microsoft fonts are not installed by default)
+		{
+			static const std::wstring arrStandardFonts[] = {
+				L"Symbol", L"Arial", L"Times New Roman", L"Tahoma", L"Cambria",
+				L"Calibri", L"Verdana", L"Georgia", L"Trebuchet MS", L"Courier New",
+				L"SimSun", L"MS Gothic", L"Nirmala UI", L"Batang", L"MS Mincho",
+				L"Wingdings", L"Microsoft JhengHei", L"Microsoft JhengHei UI",
+				L"Microsoft YaHei", L"PMingLiU", L"MingLiU", L"DFKai-SB",
+				L"FangSong", L"KaiTi", L"SimKai", L"SimHei", L"Meiryo",
+				L"Malgun Gothic", L"Nanum Gothic", L"NanumGothic", L"Noto Sans KR",
+				L"TakaoGothic"
+			};
+			for (size_t i = 0; i < (sizeof(arrStandardFonts) / sizeof(arrStandardFonts[0])); ++i)
+			{
+				if (CheckBreak()) return;
+
+				const std::wstring& sFontName = arrStandardFonts[i];
+				if (mapFonts.end() != mapFonts.find(sFontName))
+					continue;
+
+				NSFonts::CFontSelectFormat oSelect;
+				oSelect.wsName = new std::wstring(sFontName);
+
+				NSFonts::CFontInfo* pSubstitute = applicationFonts->GetList()->GetByParams(oSelect, true);
+
+				delete oSelect.wsName;
+
+				if (NULL == pSubstitute)
+					continue;
+
+				std::map<std::wstring, CFontInfoJS>::iterator pSubstitutePair = mapFonts.find(pSubstitute->m_wsFontName);
+				if (mapFonts.end() == pSubstitutePair)
+					continue;
+
+				CFontInfoJS fontInfo = pSubstitutePair->second;
+				fontInfo.m_sName = sFontName;
+				mapFonts.insert(std::pair<std::wstring, CFontInfoJS>(sFontName, fontInfo));
+				arrFonts.push_back(sFontName);
+			}
+		}
+		// -------------------------------------------
+
 		if (CheckBreak()) return;
 
 		// now sort fonts by name ----------


### PR DESCRIPTION
## What Problem This Solves

The font dropdown is built only from fonts installed on the system (see `SaveAllFontsJS` in `DesktopEditor/fontengine/ApplicationFontsWorker.cpp`). On Linux, where Microsoft fonts are not installed by default, standard fonts such as "Times New Roman" never appear in the dropdown, even when the opened document uses them. See https://github.com/ONLYOFFICE/DesktopEditors/issues/2405.

## Why This Change Was Made

- **Root cause**: `__fonts_infos` (AllFonts.js) is generated by iterating only the installed font list; fonts that are not installed are unknown to the UI. On web this is not a problem because the server ships all licensed fonts; on desktop only local fonts exist.
- **Architecture affected**: the font list generator (`ApplicationFontsWorker.cpp`) and the font substitution engine (`CFontList::GetByParams` with the likes picker in `ApplicationFonts.h`).
- **Why this solution**: instead of hard-coding substitutes, reuse the exact same selection logic the renderer uses at draw time (`GetByParams`). Each missing standard font is mapped to its best installed substitute (e.g. Times New Roman -> Liberation Serif via the likes groups). A follow-up fix in sdkjs (`FontNameMap`) makes the toolbar show the logical font name; this PR makes the font available in the dropdown and keeps the render consistent.

## User Impact

- "Times New Roman", "Cambria", "Calibri", "Arial", "Courier New" and other standard fonts now appear in the font dropdown on Linux even when the corresponding Microsoft font is not installed.
- Selecting such a font from the dropdown applies the logical name to the document; rendering uses the substitute, same as before.
- No behavior change on web (all standard fonts are already installed there, the new loop adds nothing) and no change for systems where the standard fonts are already present.

## Solution Details

- `DesktopEditor/fontengine/ApplicationFontsWorker.cpp` (`SaveAllFontsJS`): after building `mapFonts` from installed fonts, iterate a static list of standard fonts (Microsoft core fonts + standard CJK fonts). For each one not present in `mapFonts`, resolve its best installed substitute with `GetByParams(oSelect, true)` (same path as `CFontManager::LoadFontByName`) and copy the substitute entry (all four styles R/I/B/BI) into `mapFonts` under the standard font name.
- The added entries flow through the existing sorting, priorities (`mapFontsPriorityStandard`) and symbol-range logic unchanged.
- `CheckBreak` is honored inside the loop (same as the surrounding code).

## Evidence

- `g++ -fsyntax-only` on `ApplicationFontsWorker.cpp` with the core include paths: 0 errors.
- Logic verified against the full chain: `SaveAllFontsJS` (list construction), `GetFaceNamePenalty`/`IsLikeFonts` (likes groups), `GetByParams` (substitute selection).
- Full build is not feasible in this environment; CI will compile the change.

## Closes #2405